### PR TITLE
Core: Add identity and authentication support for OTC APIs

### DIFF
--- a/docs/auth-configuration.md
+++ b/docs/auth-configuration.md
@@ -1,0 +1,86 @@
+# Authentication Configuration
+
+The cloud-provider-opentelekomcloud supports two authentication methods for communicating with OTC APIs: **Password** and **AK/SK** (Access Key / Secret Key).
+
+Configuration is provided via an INI file (typically `/etc/kubernetes/cloud.conf`). Environment variables are used as fallbacks when a field is not set in the config file.
+
+## Password Authentication
+
+```ini
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+username=my-user
+password=my-password
+domain-name=my-domain
+tenant-name=eu-de_project
+region=eu-de
+```
+
+## AK/SK Authentication
+
+```ini
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+access-key=AKIA...
+secret-key=wJal...
+project-id=abc123
+region=eu-de
+domain-name=my-domain
+```
+
+### Temporary Credentials
+
+AK/SK supports temporary credentials with a security token:
+
+```ini
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+access-key=AKIA...
+secret-key=wJal...
+security-token=FwoGZXIv...
+project-id=abc123
+region=eu-de
+domain-name=my-domain
+```
+
+## TLS Configuration
+
+```ini
+[Global]
+# ... auth fields ...
+ca-file=/etc/ssl/certs/custom-ca.pem
+tls-insecure=false
+```
+
+## Environment Variables
+
+The following environment variables are used as fallbacks:
+
+| Field           | Environment Variable |
+|-----------------|---------------------|
+| auth-url        | `OS_AUTH_URL`       |
+| username        | `OS_USERNAME`       |
+| password        | `OS_PASSWORD`       |
+| access-key      | `OS_ACCESS_KEY`     |
+| secret-key      | `OS_SECRET_KEY`     |
+| security-token  | `OS_SECURITY_TOKEN` |
+| domain-name     | `OS_DOMAIN_NAME`    |
+| domain-id       | `OS_DOMAIN_ID`      |
+| tenant-id       | `OS_TENANT_ID`      |
+| tenant-name     | `OS_TENANT_NAME`    |
+| project-id      | `OS_PROJECT_ID`     |
+| region          | `OS_REGION_NAME`    |
+
+## Auth Method Priority
+
+When both password and AK/SK credentials are provided, **AK/SK takes priority**.
+
+## Kubernetes Deployment
+
+Pass the config file to the cloud-controller-manager:
+
+```bash
+cloud-controller-manager \
+  --cloud-provider=opentelekomcloud \
+  --cloud-config=/etc/kubernetes/cloud.conf
+```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/opentelekomcloud/cloud-provider-opentelekomcloud
 go 1.25.5
 
 require (
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.5
+	gopkg.in/gcfg.v1 v1.2.3
 	k8s.io/apimachinery v0.35.0
 	k8s.io/cloud-provider v0.35.0
 	k8s.io/component-base v0.35.0
@@ -91,6 +93,8 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.0 // indirect
 	k8s.io/apiextensions-apiserver v0.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.5 h1:wJMqv0xU6CcTVZAWVw2qig1j/hn7+5eulpF0A7LGWo0=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
@@ -271,10 +273,16 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
+gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
+gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
+gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/gcfg.v1"
+)
+
+const (
+	AuthMethodPassword = "password"
+	AuthMethodAKSK     = "aksk"
+)
+
+// CloudConfig holds the cloud provider configuration parsed from an INI file.
+type CloudConfig struct {
+	Global AuthOpts
+}
+
+// AuthOpts contains authentication and connection options for OTC.
+type AuthOpts struct {
+	// AuthURL is the Identity (IAM) endpoint URL.
+	AuthURL string `gcfg:"auth-url"`
+
+	// Password auth
+	Username string `gcfg:"username"`
+	Password string `gcfg:"password"`
+
+	// AK/SK auth
+	AccessKey     string `gcfg:"access-key"`
+	SecretKey     string `gcfg:"secret-key"`
+	SecurityToken string `gcfg:"security-token"`
+
+	// Scope
+	DomainName string `gcfg:"domain-name"`
+	DomainID   string `gcfg:"domain-id"`
+	TenantID   string `gcfg:"tenant-id"`
+	TenantName string `gcfg:"tenant-name"`
+	ProjectID  string `gcfg:"project-id"`
+	Region     string `gcfg:"region"`
+
+	// TLS
+	CAFile      string `gcfg:"ca-file"`
+	TLSInsecure bool   `gcfg:"tls-insecure"`
+}
+
+// AuthMethod returns the authentication method based on which credentials are set.
+// Priority: AK/SK > Password.
+func (o *AuthOpts) AuthMethod() string {
+	if o.AccessKey != "" && o.SecretKey != "" {
+		return AuthMethodAKSK
+	}
+	if o.Username != "" && o.Password != "" {
+		return AuthMethodPassword
+	}
+	return ""
+}
+
+// ReadConfig parses the cloud configuration from an INI reader, then applies
+// environment variable fallbacks for any unset fields.
+func ReadConfig(cfg io.Reader) (*CloudConfig, error) {
+	cc := &CloudConfig{}
+
+	if cfg != nil {
+		if err := gcfg.FatalOnly(gcfg.ReadInto(cc, cfg)); err != nil {
+			return nil, fmt.Errorf("failed to parse cloud config: %w", err)
+		}
+	}
+
+	applyEnvFallbacks(&cc.Global)
+
+	if err := validate(&cc.Global); err != nil {
+		return nil, err
+	}
+
+	return cc, nil
+}
+
+// applyEnvFallbacks sets AuthOpts fields from environment variables when
+// the field is not already set by the config file.
+func applyEnvFallbacks(opts *AuthOpts) {
+	setIfEmpty(&opts.AuthURL, "OS_AUTH_URL")
+	setIfEmpty(&opts.Username, "OS_USERNAME")
+	setIfEmpty(&opts.Password, "OS_PASSWORD")
+	setIfEmpty(&opts.AccessKey, "OS_ACCESS_KEY")
+	setIfEmpty(&opts.SecretKey, "OS_SECRET_KEY")
+	setIfEmpty(&opts.SecurityToken, "OS_SECURITY_TOKEN")
+	setIfEmpty(&opts.DomainName, "OS_DOMAIN_NAME")
+	setIfEmpty(&opts.DomainID, "OS_DOMAIN_ID")
+	setIfEmpty(&opts.TenantID, "OS_TENANT_ID")
+	setIfEmpty(&opts.TenantName, "OS_TENANT_NAME")
+	setIfEmpty(&opts.ProjectID, "OS_PROJECT_ID")
+	setIfEmpty(&opts.Region, "OS_REGION_NAME")
+}
+
+func setIfEmpty(field *string, envVar string) {
+	if *field == "" {
+		*field = os.Getenv(envVar)
+	}
+}
+
+// validate checks that the config has the minimum required fields.
+func validate(opts *AuthOpts) error {
+	if opts.AuthURL == "" {
+		return fmt.Errorf("auth-url is required (set in config or OS_AUTH_URL)")
+	}
+	if opts.AuthMethod() == "" {
+		return fmt.Errorf("no valid credentials: provide username/password or access-key/secret-key")
+	}
+	return nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+const passwordConfig = `
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+username=my-user
+password=my-password
+domain-name=my-domain
+tenant-name=eu-de_project
+region=eu-de
+`
+
+const akskConfig = `
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+access-key=AKIAIOSFODNN7EXAMPLE
+secret-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+project-id=abc123
+region=eu-de
+domain-name=my-domain
+`
+
+func TestReadConfig_Password(t *testing.T) {
+	cc, err := ReadConfig(strings.NewReader(passwordConfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cc.Global.AuthURL != "https://iam.eu-de.otc.t-systems.com/v3" {
+		t.Errorf("AuthURL = %q, want %q", cc.Global.AuthURL, "https://iam.eu-de.otc.t-systems.com/v3")
+	}
+	if cc.Global.Username != "my-user" {
+		t.Errorf("Username = %q, want %q", cc.Global.Username, "my-user")
+	}
+	if cc.Global.Password != "my-password" {
+		t.Errorf("Password = %q, want %q", cc.Global.Password, "my-password")
+	}
+	if cc.Global.AuthMethod() != AuthMethodPassword {
+		t.Errorf("AuthMethod() = %q, want %q", cc.Global.AuthMethod(), AuthMethodPassword)
+	}
+}
+
+func TestReadConfig_AKSK(t *testing.T) {
+	cc, err := ReadConfig(strings.NewReader(akskConfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cc.Global.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("AccessKey = %q, want %q", cc.Global.AccessKey, "AKIAIOSFODNN7EXAMPLE")
+	}
+	if cc.Global.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("SecretKey = %q, want %q", cc.Global.SecretKey, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	}
+	if cc.Global.AuthMethod() != AuthMethodAKSK {
+		t.Errorf("AuthMethod() = %q, want %q", cc.Global.AuthMethod(), AuthMethodAKSK)
+	}
+}
+
+func TestReadConfig_EnvFallback(t *testing.T) {
+	t.Setenv("OS_AUTH_URL", "https://iam.eu-de.otc.t-systems.com/v3")
+	t.Setenv("OS_ACCESS_KEY", "env-ak")
+	t.Setenv("OS_SECRET_KEY", "env-sk")
+	t.Setenv("OS_REGION_NAME", "eu-de")
+
+	cc, err := ReadConfig(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc.Global.AuthURL != "https://iam.eu-de.otc.t-systems.com/v3" {
+		t.Errorf("AuthURL = %q, want env value", cc.Global.AuthURL)
+	}
+	if cc.Global.AccessKey != "env-ak" {
+		t.Errorf("AccessKey = %q, want %q", cc.Global.AccessKey, "env-ak")
+	}
+	if cc.Global.Region != "eu-de" {
+		t.Errorf("Region = %q, want %q", cc.Global.Region, "eu-de")
+	}
+}
+
+func TestReadConfig_ConfigOverridesEnv(t *testing.T) {
+	t.Setenv("OS_AUTH_URL", "https://env-url/v3")
+	t.Setenv("OS_ACCESS_KEY", "env-ak")
+	t.Setenv("OS_SECRET_KEY", "env-sk")
+
+	cc, err := ReadConfig(strings.NewReader(akskConfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cc.Global.AuthURL != "https://iam.eu-de.otc.t-systems.com/v3" {
+		t.Errorf("AuthURL = %q, want config value not env", cc.Global.AuthURL)
+	}
+	if cc.Global.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("AccessKey = %q, want config value not env", cc.Global.AccessKey)
+	}
+}
+
+func TestReadConfig_MissingAuthURL(t *testing.T) {
+	cfg := `
+[Global]
+username=user
+password=pass
+`
+	_, err := ReadConfig(strings.NewReader(cfg))
+	if err == nil {
+		t.Fatal("expected error for missing auth-url")
+	}
+	if !strings.Contains(err.Error(), "auth-url") {
+		t.Errorf("error = %q, want mention of auth-url", err.Error())
+	}
+}
+
+func TestReadConfig_NoCredentials(t *testing.T) {
+	cfg := `
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+`
+	_, err := ReadConfig(strings.NewReader(cfg))
+	if err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+	if !strings.Contains(err.Error(), "credentials") {
+		t.Errorf("error = %q, want mention of credentials", err.Error())
+	}
+}
+
+func TestAuthOpts_AuthMethod_Priority(t *testing.T) {
+	// When both are set, AK/SK takes priority
+	opts := AuthOpts{
+		Username:  "user",
+		Password:  "pass",
+		AccessKey: "ak",
+		SecretKey: "sk",
+	}
+	if opts.AuthMethod() != AuthMethodAKSK {
+		t.Errorf("AuthMethod() = %q, want %q (AK/SK should take priority)", opts.AuthMethod(), AuthMethodAKSK)
+	}
+}

--- a/pkg/identity/aksk.go
+++ b/pkg/identity/aksk.go
@@ -1,0 +1,103 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+// akskProvider authenticates to OTC via AK/SK (HMAC-SHA256 request signing).
+type akskProvider struct {
+	opts   config.AuthOpts
+	client *golangsdk.ProviderClient
+	mu     sync.Mutex
+}
+
+// NewAKSKProvider creates an IdentityProvider that authenticates using AK/SK credentials.
+func NewAKSKProvider(opts config.AuthOpts) (IdentityProvider, error) {
+	if opts.AccessKey == "" || opts.SecretKey == "" {
+		return nil, fmt.Errorf("access-key and secret-key are required for AK/SK auth")
+	}
+	if opts.AuthURL == "" {
+		return nil, fmt.Errorf("auth-url is required")
+	}
+	return &akskProvider{opts: opts}, nil
+}
+
+func (p *akskProvider) authenticate() (*golangsdk.ProviderClient, error) {
+	client, err := openstack.NewClient(p.opts.AuthURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OpenStack client: %w", err)
+	}
+
+	transport, err := buildTransport(p.opts)
+	if err != nil {
+		return nil, err
+	}
+	client.HTTPClient = http.Client{Transport: transport}
+	client.UserAgent.Prepend("cloud-provider-opentelekomcloud")
+
+	akskOpts := golangsdk.AKSKAuthOptions{
+		IdentityEndpoint: p.opts.AuthURL,
+		AccessKey:        p.opts.AccessKey,
+		SecretKey:        p.opts.SecretKey,
+		SecurityToken:    p.opts.SecurityToken,
+		ProjectId:        p.opts.ProjectID,
+		ProjectName:      p.opts.TenantName,
+		Region:           p.opts.Region,
+		Domain:           p.opts.DomainName,
+		DomainID:         p.opts.DomainID,
+	}
+
+	if err := openstack.Authenticate(client, akskOpts); err != nil {
+		return nil, fmt.Errorf("AK/SK authentication failed: %w", err)
+	}
+	return client, nil
+}
+
+func (p *akskProvider) GetProvider(_ context.Context) (*golangsdk.ProviderClient, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.client != nil {
+		return p.client, nil
+	}
+
+	client, err := p.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	p.client = client
+	return p.client, nil
+}
+
+func (p *akskProvider) GetServiceClient(ctx context.Context, _ string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	provider, err := p.GetProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := provider.EndpointLocator(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate endpoint: %w", err)
+	}
+
+	return &golangsdk.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       endpoint,
+	}, nil
+}
+
+func (p *akskProvider) AuthMethod() string {
+	return config.AuthMethodAKSK
+}
+
+func (p *akskProvider) Region() string {
+	return p.opts.Region
+}

--- a/pkg/identity/aksk_test.go
+++ b/pkg/identity/aksk_test.go
@@ -1,0 +1,144 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+func newMockAKSKServer(t *testing.T, authHeaders *[]string, mu *sync.Mutex) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Version discovery endpoint
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			// Capture Authorization header for non-root requests
+			if authHeaders != nil {
+				mu.Lock()
+				*authHeaders = append(*authHeaders, r.Header.Get("Authorization"))
+				mu.Unlock()
+			}
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"versions": map[string]interface{}{
+				"values": []map[string]interface{}{
+					{
+						"id":     "v3.0",
+						"status": "stable",
+						"links": []map[string]interface{}{
+							{"rel": "self", "href": ""},
+						},
+					},
+				},
+			},
+		})
+	})
+
+	// Identity v3 endpoint
+	mux.HandleFunc("/v3/", func(w http.ResponseWriter, r *http.Request) {
+		// Capture Authorization header
+		if authHeaders != nil {
+			mu.Lock()
+			*authHeaders = append(*authHeaders, r.Header.Get("Authorization"))
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Auth catalog endpoint
+	mux.HandleFunc("/v3/auth/catalog", func(w http.ResponseWriter, r *http.Request) {
+		if authHeaders != nil {
+			mu.Lock()
+			*authHeaders = append(*authHeaders, r.Header.Get("Authorization"))
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"catalog": []map[string]interface{}{
+				{
+					"type": "compute",
+					"name": "nova",
+					"endpoints": []map[string]interface{}{
+						{
+							"url":       "https://compute.example.com/v2.1",
+							"region":    "eu-de",
+							"interface": "public",
+							"id":        "ep-1",
+						},
+					},
+				},
+			},
+			"links": map[string]interface{}{
+				"self":     "https://iam.example.com/v3/auth/catalog",
+				"previous": nil,
+				"next":     nil,
+			},
+		})
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestAKSKProvider_Authenticate(t *testing.T) {
+	var authHeaders []string
+	var mu sync.Mutex
+	server := newMockAKSKServer(t, &authHeaders, &mu)
+	defer server.Close()
+
+	opts := config.AuthOpts{
+		AuthURL:    server.URL + "/v3",
+		AccessKey:  "AKIAIOSFODNN7EXAMPLE",
+		SecretKey:  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		ProjectID:  "test-project-id",
+		DomainName: "test-domain",
+		Region:     "eu-de",
+	}
+
+	provider, err := NewAKSKProvider(opts)
+	if err != nil {
+		t.Fatalf("unexpected error creating provider: %v", err)
+	}
+
+	client, err := provider.GetProvider(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error authenticating: %v", err)
+	}
+
+	if client.AKSKAuthOptions.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("AccessKey = %q, want %q", client.AKSKAuthOptions.AccessKey, "AKIAIOSFODNN7EXAMPLE")
+	}
+
+	// Verify SDK-HMAC-SHA256 headers were used in requests
+	mu.Lock()
+	defer mu.Unlock()
+	foundHMAC := false
+	for _, h := range authHeaders {
+		if strings.HasPrefix(h, "SDK-HMAC-SHA256") {
+			foundHMAC = true
+			break
+		}
+	}
+	if !foundHMAC {
+		t.Errorf("expected SDK-HMAC-SHA256 Authorization header in requests, got: %v", authHeaders)
+	}
+}
+
+func TestAKSKProvider_MissingCredentials(t *testing.T) {
+	_, err := NewAKSKProvider(config.AuthOpts{
+		AuthURL: "https://iam.example.com/v3",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing AK/SK credentials")
+	}
+}

--- a/pkg/identity/factory.go
+++ b/pkg/identity/factory.go
@@ -1,0 +1,20 @@
+package identity
+
+import (
+	"fmt"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+// NewIdentityProvider creates the appropriate IdentityProvider based on
+// configured credentials. Priority: AK/SK > Password.
+func NewIdentityProvider(opts config.AuthOpts) (IdentityProvider, error) {
+	switch opts.AuthMethod() {
+	case config.AuthMethodAKSK:
+		return NewAKSKProvider(opts)
+	case config.AuthMethodPassword:
+		return NewPasswordProvider(opts)
+	default:
+		return nil, fmt.Errorf("no valid auth credentials found: provide username/password or access-key/secret-key")
+	}
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,0 +1,19 @@
+package identity
+
+import (
+	"context"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// IdentityProvider abstracts OTC authentication and service client creation.
+type IdentityProvider interface {
+	// GetProvider returns an authenticated ProviderClient.
+	GetProvider(ctx context.Context) (*golangsdk.ProviderClient, error)
+	// GetServiceClient returns a ServiceClient for the given service type.
+	GetServiceClient(ctx context.Context, service string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error)
+	// AuthMethod returns the authentication method name (e.g., "password", "aksk").
+	AuthMethod() string
+	// Region returns the configured cloud region.
+	Region() string
+}

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -1,0 +1,76 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+func TestNewIdentityProvider_AKSK(t *testing.T) {
+	opts := config.AuthOpts{
+		AuthURL:   "https://iam.eu-de.otc.t-systems.com/v3",
+		AccessKey: "AKIAIOSFODNN7EXAMPLE",
+		SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		Region:    "eu-de",
+	}
+
+	provider, err := NewIdentityProvider(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider.AuthMethod() != config.AuthMethodAKSK {
+		t.Errorf("AuthMethod() = %q, want %q", provider.AuthMethod(), config.AuthMethodAKSK)
+	}
+	if provider.Region() != "eu-de" {
+		t.Errorf("Region() = %q, want %q", provider.Region(), "eu-de")
+	}
+}
+
+func TestNewIdentityProvider_Password(t *testing.T) {
+	opts := config.AuthOpts{
+		AuthURL:    "https://iam.eu-de.otc.t-systems.com/v3",
+		Username:   "user",
+		Password:   "pass",
+		DomainName: "domain",
+		Region:     "eu-de",
+	}
+
+	provider, err := NewIdentityProvider(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider.AuthMethod() != config.AuthMethodPassword {
+		t.Errorf("AuthMethod() = %q, want %q", provider.AuthMethod(), config.AuthMethodPassword)
+	}
+}
+
+func TestNewIdentityProvider_AKSKPriority(t *testing.T) {
+	// When both credential types are present, AK/SK should be chosen
+	opts := config.AuthOpts{
+		AuthURL:   "https://iam.eu-de.otc.t-systems.com/v3",
+		Username:  "user",
+		Password:  "pass",
+		AccessKey: "ak",
+		SecretKey: "sk",
+		Region:    "eu-de",
+	}
+
+	provider, err := NewIdentityProvider(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider.AuthMethod() != config.AuthMethodAKSK {
+		t.Errorf("AuthMethod() = %q, want %q (AK/SK should take priority)", provider.AuthMethod(), config.AuthMethodAKSK)
+	}
+}
+
+func TestNewIdentityProvider_NoCredentials(t *testing.T) {
+	opts := config.AuthOpts{
+		AuthURL: "https://iam.eu-de.otc.t-systems.com/v3",
+	}
+
+	_, err := NewIdentityProvider(opts)
+	if err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+}

--- a/pkg/identity/password.go
+++ b/pkg/identity/password.go
@@ -1,0 +1,130 @@
+package identity
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+// passwordProvider authenticates to OTC via username/password (Keystone v3).
+type passwordProvider struct {
+	opts   config.AuthOpts
+	client *golangsdk.ProviderClient
+	mu     sync.Mutex
+}
+
+// NewPasswordProvider creates an IdentityProvider that authenticates using username/password.
+func NewPasswordProvider(opts config.AuthOpts) (IdentityProvider, error) {
+	if opts.Username == "" || opts.Password == "" {
+		return nil, fmt.Errorf("username and password are required for password auth")
+	}
+	if opts.AuthURL == "" {
+		return nil, fmt.Errorf("auth-url is required")
+	}
+	return &passwordProvider{opts: opts}, nil
+}
+
+func (p *passwordProvider) authenticate() (*golangsdk.ProviderClient, error) {
+	client, err := openstack.NewClient(p.opts.AuthURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OpenStack client: %w", err)
+	}
+
+	transport, err := buildTransport(p.opts)
+	if err != nil {
+		return nil, err
+	}
+	client.HTTPClient = http.Client{Transport: transport}
+	client.UserAgent.Prepend("cloud-provider-opentelekomcloud")
+
+	authOpts := golangsdk.AuthOptions{
+		IdentityEndpoint: p.opts.AuthURL,
+		Username:         p.opts.Username,
+		Password:         p.opts.Password,
+		DomainName:       p.opts.DomainName,
+		DomainID:         p.opts.DomainID,
+		TenantID:         p.opts.TenantID,
+		TenantName:       p.opts.TenantName,
+		AllowReauth:      true,
+	}
+
+	if err := openstack.Authenticate(client, authOpts); err != nil {
+		return nil, fmt.Errorf("authentication failed: %w", err)
+	}
+	return client, nil
+}
+
+func (p *passwordProvider) GetProvider(_ context.Context) (*golangsdk.ProviderClient, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.client != nil {
+		return p.client, nil
+	}
+
+	client, err := p.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	p.client = client
+	return p.client, nil
+}
+
+func (p *passwordProvider) GetServiceClient(ctx context.Context, _ string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	provider, err := p.GetProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := provider.EndpointLocator(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate endpoint: %w", err)
+	}
+
+	return &golangsdk.ServiceClient{
+		ProviderClient: provider,
+		Endpoint:       endpoint,
+	}, nil
+}
+
+func (p *passwordProvider) AuthMethod() string {
+	return config.AuthMethodPassword
+}
+
+func (p *passwordProvider) Region() string {
+	return p.opts.Region
+}
+
+// buildTransport creates an http.Transport with optional TLS configuration.
+func buildTransport(opts config.AuthOpts) (*http.Transport, error) {
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if opts.TLSInsecure {
+		tlsConfig.InsecureSkipVerify = true // #nosec G402
+	}
+
+	if opts.CAFile != "" {
+		caCert, err := os.ReadFile(opts.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA file %s: %w", opts.CAFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %s", opts.CAFile)
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	return &http.Transport{TLSClientConfig: tlsConfig}, nil
+}

--- a/pkg/identity/password_test.go
+++ b/pkg/identity/password_test.go
@@ -1,0 +1,170 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+// keystoneTokenResponse returns a minimal Keystone v3 token response.
+func keystoneTokenResponse() map[string]interface{} {
+	return map[string]interface{}{
+		"token": map[string]interface{}{
+			"methods":    []string{"password"},
+			"expires_at": "2099-01-01T00:00:00.000000Z",
+			"user": map[string]interface{}{
+				"id":   "user-id",
+				"name": "test-user",
+				"domain": map[string]interface{}{
+					"id":   "domain-id",
+					"name": "test-domain",
+				},
+			},
+			"project": map[string]interface{}{
+				"id":   "project-id",
+				"name": "test-project",
+				"domain": map[string]interface{}{
+					"id":   "domain-id",
+					"name": "test-domain",
+				},
+			},
+			"catalog": []map[string]interface{}{
+				{
+					"type": "compute",
+					"name": "nova",
+					"endpoints": []map[string]interface{}{
+						{
+							"url":       "https://compute.example.com/v2.1",
+							"region":    "eu-de",
+							"interface": "public",
+							"id":        "ep-1",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newMockKeystoneServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Version discovery endpoint
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"versions": map[string]interface{}{
+				"values": []map[string]interface{}{
+					{
+						"id":     "v3.0",
+						"status": "stable",
+						"links": []map[string]interface{}{
+							{"rel": "self", "href": ""},
+						},
+					},
+				},
+			},
+		})
+	})
+
+	// Token creation endpoint
+	mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Subject-Token", "test-token-id")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(keystoneTokenResponse())
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestPasswordProvider_Authenticate(t *testing.T) {
+	server := newMockKeystoneServer(t)
+	defer server.Close()
+
+	opts := config.AuthOpts{
+		AuthURL:    server.URL + "/v3",
+		Username:   "test-user",
+		Password:   "test-password",
+		DomainName: "test-domain",
+		TenantName: "test-project",
+		Region:     "eu-de",
+	}
+
+	provider, err := NewPasswordProvider(opts)
+	if err != nil {
+		t.Fatalf("unexpected error creating provider: %v", err)
+	}
+
+	client, err := provider.GetProvider(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error authenticating: %v", err)
+	}
+
+	if client.TokenID == "" {
+		t.Error("expected non-empty TokenID after authentication")
+	}
+}
+
+func TestPasswordProvider_AuthFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"versions": map[string]interface{}{
+					"values": []map[string]interface{}{
+						{
+							"id":     "v3.0",
+							"status": "stable",
+							"links": []map[string]interface{}{
+								{"rel": "self", "href": ""},
+							},
+						},
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, `{"error": {"message": "unauthorized"}}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	opts := config.AuthOpts{
+		AuthURL:    server.URL + "/v3",
+		Username:   "bad-user",
+		Password:   "bad-pass",
+		DomainName: "domain",
+	}
+
+	provider, err := NewPasswordProvider(opts)
+	if err != nil {
+		t.Fatalf("unexpected error creating provider: %v", err)
+	}
+
+	_, err = provider.GetProvider(context.Background())
+	if err == nil {
+		t.Fatal("expected authentication error")
+	}
+}
+
+func TestPasswordProvider_MissingCredentials(t *testing.T) {
+	_, err := NewPasswordProvider(config.AuthOpts{
+		AuthURL: "https://iam.example.com/v3",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing username/password")
+	}
+}

--- a/pkg/identity/token_cache.go
+++ b/pkg/identity/token_cache.go
@@ -1,0 +1,88 @@
+package identity
+
+import (
+	"context"
+	"time"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"k8s.io/klog/v2"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+const defaultRefreshInterval = 23 * time.Hour
+
+// tokenCacheProvider wraps an IdentityProvider and proactively refreshes
+// the authentication token before it expires. For AK/SK providers this is
+// a no-op passthrough since each request is individually signed.
+type tokenCacheProvider struct {
+	inner    IdentityProvider
+	interval time.Duration
+}
+
+// WithTokenCache wraps an IdentityProvider with proactive token refresh.
+// For AK/SK auth this returns the original provider unchanged (no tokens to refresh).
+// The stop channel is used to terminate the background refresh goroutine.
+// If interval is nil, the default refresh interval (23h) is used.
+func WithTokenCache(provider IdentityProvider, interval *time.Duration, stop <-chan struct{}) IdentityProvider {
+	if provider.AuthMethod() == config.AuthMethodAKSK {
+		return provider
+	}
+
+	refreshInterval := defaultRefreshInterval
+	if interval != nil {
+		refreshInterval = *interval
+	}
+
+	cached := &tokenCacheProvider{
+		inner:    provider,
+		interval: refreshInterval,
+	}
+
+	go cached.refreshLoop(stop)
+
+	return cached
+}
+
+func (c *tokenCacheProvider) refreshLoop(stop <-chan struct{}) {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			klog.Info("Token refresh goroutine stopped")
+			return
+		case <-ticker.C:
+			klog.V(4).Info("Proactively refreshing authentication token")
+			provider, err := c.inner.GetProvider(context.Background())
+			if err != nil {
+				klog.Warningf("Failed to get provider for token refresh: %v", err)
+				continue
+			}
+			if provider.ReauthFunc != nil {
+				if err := provider.ReauthFunc(); err != nil {
+					klog.Warningf("Proactive token refresh failed: %v", err)
+				} else {
+					klog.V(4).Info("Proactive token refresh succeeded")
+				}
+			}
+		}
+	}
+}
+
+func (c *tokenCacheProvider) GetProvider(ctx context.Context) (*golangsdk.ProviderClient, error) {
+	return c.inner.GetProvider(ctx)
+}
+
+func (c *tokenCacheProvider) GetServiceClient(ctx context.Context, service string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return c.inner.GetServiceClient(ctx, service, opts)
+}
+
+func (c *tokenCacheProvider) AuthMethod() string {
+	return c.inner.AuthMethod()
+}
+
+func (c *tokenCacheProvider) Region() string {
+	return c.inner.Region()
+}

--- a/pkg/identity/token_cache_test.go
+++ b/pkg/identity/token_cache_test.go
@@ -1,0 +1,128 @@
+package identity
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+type mockIdentityProvider struct {
+	authMethod string
+	region     string
+	client     *golangsdk.ProviderClient
+}
+
+func (m *mockIdentityProvider) GetProvider(_ context.Context) (*golangsdk.ProviderClient, error) {
+	return m.client, nil
+}
+
+func (m *mockIdentityProvider) GetServiceClient(_ context.Context, _ string, _ golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return &golangsdk.ServiceClient{ProviderClient: m.client}, nil
+}
+
+func (m *mockIdentityProvider) AuthMethod() string { return m.authMethod }
+func (m *mockIdentityProvider) Region() string     { return m.region }
+
+func TestWithTokenCache_AKSKPassthrough(t *testing.T) {
+	mock := &mockIdentityProvider{
+		authMethod: config.AuthMethodAKSK,
+		region:     "eu-de",
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	result := WithTokenCache(mock, nil, stop)
+
+	// For AK/SK, WithTokenCache should return the original provider
+	if result != mock {
+		t.Error("expected AK/SK provider to be returned unchanged")
+	}
+}
+
+func TestWithTokenCache_PasswordWrapped(t *testing.T) {
+	mock := &mockIdentityProvider{
+		authMethod: config.AuthMethodPassword,
+		region:     "eu-de",
+		client:     &golangsdk.ProviderClient{},
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	result := WithTokenCache(mock, nil, stop)
+
+	if result == mock {
+		t.Error("expected password provider to be wrapped")
+	}
+	if result.AuthMethod() != config.AuthMethodPassword {
+		t.Errorf("AuthMethod() = %q, want %q", result.AuthMethod(), config.AuthMethodPassword)
+	}
+	if result.Region() != "eu-de" {
+		t.Errorf("Region() = %q, want %q", result.Region(), "eu-de")
+	}
+}
+
+func TestWithTokenCache_RefreshFires(t *testing.T) {
+	var refreshCount int64
+
+	client := &golangsdk.ProviderClient{}
+	client.ReauthFunc = func() error {
+		atomic.AddInt64(&refreshCount, 1)
+		return nil
+	}
+
+	mock := &mockIdentityProvider{
+		authMethod: config.AuthMethodPassword,
+		region:     "eu-de",
+		client:     client,
+	}
+
+	stop := make(chan struct{})
+	interval := 50 * time.Millisecond
+	_ = WithTokenCache(mock, &interval, stop)
+
+	// Wait for at least one refresh to happen
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+
+	count := atomic.LoadInt64(&refreshCount)
+	if count == 0 {
+		t.Error("expected at least one proactive refresh to fire")
+	}
+}
+
+func TestWithTokenCache_StopChannel(t *testing.T) {
+	var refreshCount int64
+
+	client := &golangsdk.ProviderClient{}
+	client.ReauthFunc = func() error {
+		atomic.AddInt64(&refreshCount, 1)
+		return nil
+	}
+
+	mock := &mockIdentityProvider{
+		authMethod: config.AuthMethodPassword,
+		region:     "eu-de",
+		client:     client,
+	}
+
+	stop := make(chan struct{})
+	interval := 50 * time.Millisecond
+	_ = WithTokenCache(mock, &interval, stop)
+
+	// Stop immediately
+	close(stop)
+	time.Sleep(150 * time.Millisecond)
+
+	count := atomic.LoadInt64(&refreshCount)
+	// Should have 0 or at most 1 refresh (race between ticker and stop)
+	if count > 1 {
+		t.Errorf("expected at most 1 refresh after stop, got %d", count)
+	}
+}

--- a/pkg/opentelekomcloud/opentelekomcloud.go
+++ b/pkg/opentelekomcloud/opentelekomcloud.go
@@ -2,7 +2,12 @@ package opentelekomcloud
 
 import (
 	"io"
+
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/identity"
 )
 
 const (
@@ -10,8 +15,8 @@ const (
 )
 
 func init() {
-	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		otc, err := NewOTC(config)
+	cloudprovider.RegisterCloudProvider(ProviderName, func(cfg io.Reader) (cloudprovider.Interface, error) {
+		otc, err := NewOTC(cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -21,8 +26,38 @@ func init() {
 
 type CloudProvider struct {
 	cloudprovider.Interface
+	identity identity.IdentityProvider
+	config   *config.CloudConfig
 }
 
 func NewOTC(cfg io.Reader) (*CloudProvider, error) {
-	return &CloudProvider{}, nil
+	cc, err := config.ReadConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	idProvider, err := identity.NewIdentityProvider(cc.Global)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.Infof("OTC cloud provider initialized with auth method: %s", idProvider.AuthMethod())
+
+	return &CloudProvider{
+		identity: idProvider,
+		config:   cc,
+	}, nil
+}
+
+func (cp *CloudProvider) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+	cp.identity = identity.WithTokenCache(cp.identity, nil, stop)
+	klog.Info("OTC cloud provider token cache initialized")
+}
+
+func (cp *CloudProvider) ProviderName() string {
+	return ProviderName
+}
+
+func (cp *CloudProvider) HasClusterID() bool {
+	return true
 }

--- a/pkg/opentelekomcloud/opentelekomcloud_test.go
+++ b/pkg/opentelekomcloud/opentelekomcloud_test.go
@@ -1,13 +1,24 @@
 package opentelekomcloud
 
 import (
+	"strings"
 	"testing"
 
 	cloudprovider "k8s.io/cloud-provider"
 )
 
+const testConfig = `[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+access-key=test-ak
+secret-key=test-sk
+project-id=test-project
+region=eu-de
+domain-name=test-domain
+`
+
 func TestProviderRegistered(t *testing.T) {
-	provider, err := cloudprovider.GetCloudProvider(ProviderName, nil)
+	cfg := strings.NewReader(testConfig)
+	provider, err := cloudprovider.GetCloudProvider(ProviderName, cfg)
 	if err != nil {
 		t.Fatalf("provider %q not registered: %v", ProviderName, err)
 	}
@@ -17,11 +28,18 @@ func TestProviderRegistered(t *testing.T) {
 }
 
 func TestNewOTC(t *testing.T) {
-	cp, err := NewOTC(nil)
+	cfg := strings.NewReader(testConfig)
+	cp, err := NewOTC(cfg)
 	if err != nil {
 		t.Fatalf("NewOTC returned error: %v", err)
 	}
 	if cp == nil {
 		t.Fatal("NewOTC returned nil")
+	}
+	if cp.ProviderName() != ProviderName {
+		t.Errorf("expected provider name %q, got %q", ProviderName, cp.ProviderName())
+	}
+	if !cp.HasClusterID() {
+		t.Error("expected HasClusterID to return true")
 	}
 }


### PR DESCRIPTION
Implement identity/authentication layer for OTC APIs.

- Password and AK/SK authentication
- INI config parsing with OS_* env var fallback
- Token refresh (23h interval) with graceful shutdown
- Integrated into CloudProvider: NewOTC() parses config and creates identity provider, Initialize() enables token caching

Closes: #8