### PR TITLE
Add ELBv3 LoadBalancer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,18 @@ go.work
 
 # local gopath
 .go
+
+# Terraform (e2e stand)
+**/.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+terraform.tfvars
+
+# Local cluster configs and e2e stand artifacts
+kubeconfig
+hack/e2e-infra/cloud-provider-opentelekomcloud
+
+# Env files with credentials
+.env
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.25 AS builder
+ARG VERSION=v0.0.0-dev
+ARG COMMIT=unknown
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath \
+    -ldflags="-s -w \
+      -X k8s.io/component-base/version.gitVersion=${VERSION} \
+      -X k8s.io/component-base/version.gitCommit=${COMMIT}" \
+    -o /cloud-provider-opentelekomcloud ./cmd/cloud-controller-manager
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /cloud-provider-opentelekomcloud /bin/cloud-provider-opentelekomcloud
+USER 65532:65532
+ENTRYPOINT ["/bin/cloud-provider-opentelekomcloud"]

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,38 @@ export PATH:=/usr/local/go/bin:$(PATH)
 
 BINARY_NAME := cloud-provider-opentelekomcloud
 BIN_DIR := bin
+# component-base requires a vX.Y.Z-prefixed version string
+VERSION ?= $(shell git describe --tags 2>/dev/null || echo "v0.0.0-$(shell git rev-parse --short HEAD 2>/dev/null || echo dev)")
+COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+# Stamp k8s.io/component-base/version so --version reports the real build.
+LDFLAGS := -X k8s.io/component-base/version.gitVersion=$(VERSION) \
+	-X k8s.io/component-base/version.gitCommit=$(COMMIT) \
+	-X k8s.io/component-base/version.buildDate=$(BUILD_DATE)
 
 default: build
 
 build:
-	@echo "Building $(BINARY_NAME)"
+	@echo "Building $(BINARY_NAME) $(VERSION)"
 	@mkdir -p $(BIN_DIR)
-	@go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/cloud-controller-manager
+	@go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/cloud-controller-manager
 
 test:
 	@echo "Running unit tests"
 	@go test ./... -v -count=1
+
+test-e2e:
+	@echo "Running e2e tests against the current KUBECONFIG cluster"
+	@go test -tags e2e ./test/e2e/ -v -count=1 -timeout 40m
+
+test-smoke:
+	@echo "Running cloud smoke test (clouds.yaml / OS_* credentials)"
+	@go test -tags smoke ./test/smoke/ -v -count=1 -timeout 20m
+
+image:
+	@echo "Building container image $(BINARY_NAME):$(VERSION)"
+	@docker build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) \
+		-t $(BINARY_NAME):$(VERSION) .
 
 fmt:
 	@echo "Running go fmt"
@@ -30,4 +51,4 @@ vet:
 clean:
 	@rm -rf $(BIN_DIR)
 
-.PHONY: build test fmt lint vet clean
+.PHONY: build test test-e2e test-smoke image fmt lint vet clean

--- a/README.md
+++ b/README.md
@@ -1,26 +1,76 @@
 # Kubernetes Cloud Provider for Open Telekom Cloud
 
-The Open Telekom Cloud Controller Manager provides the interface between a Kubernetes cluster and Open Telekom Cloud service APIs.
-This project allows a Kubernetes cluster to provision, monitor, and remove Open Telekom Cloud resources necessary for the operation of the cluster.
+The Open Telekom Cloud Controller Manager (CCM) connects a self-managed
+Kubernetes cluster to Open Telekom Cloud APIs. It watches Services of
+`type: LoadBalancer` and provisions dedicated ELBv3 load balancers for them,
+so applications get a working `EXTERNAL-IP` on OTC just like on any managed
+cloud.
 
 See [Cloud Controller Manager Administration](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/)
-for more about Kubernetes cloud controller manager.
+for background on the CCM concept.
 
-## Implementation Details
+## Features
 
-Currently `opentelekomcloud-cloud-controller-manager` is in early development. No controllers are implemented yet.
+| Feature | Status |
+|---|---|
+| `Service` type `LoadBalancer` (dedicated ELBv3) | ✅ TCP/UDP listeners, pools, members, health monitors |
+| Health checks | ✅ TCP/UDP_CONNECT/HTTP/HTTPS, fully configurable |
+| `externalTrafficPolicy: Local` | ✅ via kube-proxy healthz probes |
+| Session affinity (`ClientIP`) | ✅ SOURCE_IP persistence incl. timeout |
+| `loadBalancerSourceRanges` | ✅ via ELB IP address groups (whitelist) |
+| Public access | ✅ bind existing EIPs or auto-create/release one |
+| Shared (pre-existing) load balancers | ✅ via the `id` annotation |
+| Authentication | ✅ AK/SK and username/password |
+| Node controllers (Instances API) | ❌ not yet – run kubelet without `--cloud-provider=external` |
+| Routes | ❌ not planned (CNI handles routing) |
+
+The full annotation reference and behavior details are in
+[docs/loadbalancer.md](docs/loadbalancer.md); authentication options in
+[docs/auth-configuration.md](docs/auth-configuration.md).
+
+## Quick start
+
+1. Fill in [manifests/cloud-config](manifests/cloud-config) (credentials +
+   `[LoadBalancer]` subnet/AZ) and create the secret:
+
+   ```sh
+   kubectl create secret -n kube-system generic cloud-config \
+     --from-file=manifests/cloud-config
+   ```
+
+2. Deploy RBAC and the controller manager:
+
+   ```sh
+   kubectl apply -f manifests/rbac-cloud-controller-manager.yaml
+   kubectl apply -f manifests/cloud-controller-manager.yaml
+   ```
+
+3. Create a LoadBalancer Service (see [examples/loadbalancer](examples/loadbalancer)):
+
+   ```sh
+   kubectl apply -f examples/loadbalancer/
+   kubectl get svc -w   # wait for EXTERNAL-IP
+   ```
+
+## Building and testing
+
+```sh
+make build       # binary in bin/
+make image       # container image
+make test        # unit tests (no cloud access needed)
+make test-smoke  # lifecycle against the real OTC API, no cluster required
+make test-e2e    # functional tests against a live cluster
+```
+
+The smoke and e2e tests are opt-in and skip without credentials; see
+[test/smoke](test/smoke) and [test/e2e](test/e2e). A disposable single-node
+test cluster can be provisioned with [hack/e2e-infra](hack/e2e-infra).
 
 ## Compatibility with Kubernetes
 
 | Kubernetes Version | Latest CCM Version |
 |--------------------|--------------------|
 | v1.31+             | v0.1.0             |
-
-## More About Cloud Controller Manager
-
-- [Concepts Underlying the Cloud Controller Manager](https://kubernetes.io/docs/concepts/architecture/cloud-controller/)
-- [Running cloud controller manager](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager)
-- [Developing Cloud Controller Manager](https://kubernetes.io/docs/tasks/administer-cluster/developing-cloud-controller-manager/)
 
 ## Support
 

--- a/docs/loadbalancer.md
+++ b/docs/loadbalancer.md
@@ -1,0 +1,166 @@
+# Service type LoadBalancer
+
+The cloud controller manager provisions Open Telekom Cloud **ELBv3 (dedicated)
+load balancers** for Kubernetes Services of type `LoadBalancer`. For every
+Service port it creates a listener, a backend server group (pool), one backend
+member per cluster node (targeting the Service NodePort) and, by default, a
+health monitor.
+
+## Cloud configuration
+
+Defaults for all Services are set in the `[LoadBalancer]` section of the cloud
+config file (the file passed via `--cloud-config`):
+
+```ini
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+access-key=<AK>
+secret-key=<SK>
+project-id=<project id>
+region=eu-de
+domain-name=<domain name>
+
+[LoadBalancer]
+# Neutron subnet ID used for the load balancer VIP (required for creation)
+subnet-id=00000000-0000-0000-0000-000000000000
+# VPC (router) ID the load balancer belongs to
+vpc-id=00000000-0000-0000-0000-000000000000
+# Availability zones for the dedicated load balancer, repeat for multiple
+availability-zone=eu-de-01
+availability-zone=eu-de-02
+# Optional L4 flavor
+#l4-flavor-id=00000000-0000-0000-0000-000000000000
+# Pool algorithm: ROUND_ROBIN (default), LEAST_CONNECTIONS or SOURCE_IP
+#lb-algorithm=ROUND_ROBIN
+# Health monitor defaults
+#health-check-enabled=true
+#health-check-delay=5
+#health-check-timeout=3
+#health-check-max-retries=3
+```
+
+## Service annotations
+
+Per-Service overrides use the `loadbalancer.opentelekomcloud.com/` prefix:
+
+| Annotation | Description |
+|---|---|
+| `loadbalancer.opentelekomcloud.com/id` | Reuse an existing load balancer by ID. The provider only manages its own listeners on it and never deletes it. |
+| `loadbalancer.opentelekomcloud.com/subnet-id` | VIP subnet override (neutron subnet ID). |
+| `loadbalancer.opentelekomcloud.com/vpc-id` | VPC ID override. |
+| `loadbalancer.opentelekomcloud.com/availability-zones` | Comma-separated AZ list, e.g. `eu-de-01,eu-de-02`. |
+| `loadbalancer.opentelekomcloud.com/l4-flavor-id` | L4 flavor override. |
+| `loadbalancer.opentelekomcloud.com/lb-algorithm` | Pool algorithm override. |
+| `loadbalancer.opentelekomcloud.com/eip-ids` | Comma-separated list of existing EIP IDs bound to the load balancer at creation. These EIPs are never released by the provider. Mutually exclusive with `eip-bandwidth`. |
+| `loadbalancer.opentelekomcloud.com/eip-bandwidth` | Create a new EIP with the given bandwidth (Mbit/s) together with the load balancer and release it again when the Service is deleted. Mutually exclusive with `eip-ids`. |
+| `loadbalancer.opentelekomcloud.com/eip-type` | Network type of the EIP created via `eip-bandwidth`. Default `5_bgp`. |
+| `loadbalancer.opentelekomcloud.com/eip-keep` | `true` keeps an EIP created via `eip-bandwidth` when the Service is deleted instead of releasing it. Default `false`. |
+| `loadbalancer.opentelekomcloud.com/idle-timeout` | Listener keepalive (idle) timeout in seconds. Unset keeps the cloud default. |
+| `loadbalancer.opentelekomcloud.com/health-check-enabled` | `true`/`false` – toggle health monitors. |
+| `loadbalancer.opentelekomcloud.com/health-check-delay` | Probe interval in seconds. |
+| `loadbalancer.opentelekomcloud.com/health-check-timeout` | Probe timeout in seconds. |
+| `loadbalancer.opentelekomcloud.com/health-check-max-retries` | Probe retry count. |
+| `loadbalancer.opentelekomcloud.com/health-check-protocol` | Probe protocol for TCP ports: `TCP` (default), `HTTP` or `HTTPS`. UDP ports always use `UDP_CONNECT`. |
+| `loadbalancer.opentelekomcloud.com/health-check-url-path` | Request path for HTTP/HTTPS probes, must start with `/`. Default `/`. |
+| `loadbalancer.opentelekomcloud.com/health-check-http-method` | Request method for HTTP/HTTPS probes. Default `GET`. |
+
+`Service.spec.loadBalancerIP` (deprecated in Kubernetes but still honored) sets
+the VIP address at creation time. `Service.spec.sessionAffinity: ClientIP` maps
+to `SOURCE_IP` session persistence on the pool, with
+`sessionAffinityConfig.clientIP.timeoutSeconds` converted to the ELB
+persistence timeout (minutes, clamped to 1–60). Note: once enabled, session
+persistence cannot be switched off again on a live pool; recreate the Service
+to remove it.
+
+With `externalTrafficPolicy: Local` the health monitor probes the kube-proxy
+`healthz` endpoint (`spec.healthCheckNodePort`) over HTTP, so the load
+balancer only routes to nodes that host at least one Service endpoint and
+client source IPs are preserved. For UDP ports the monitor stays
+`UDP_CONNECT` on the member port.
+
+`spec.loadBalancerSourceRanges` is enforced through an ELB IP address group
+(whitelist) attached to every listener: only the listed CIDRs may connect.
+Clearing the ranges disables the whitelist again.
+
+Only `TCP` and `UDP` ports are supported (ELB L4 listeners).
+
+## Example
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: default
+  annotations:
+    loadbalancer.opentelekomcloud.com/health-check-delay: "10"
+    # HTTP probe instead of a plain TCP connect check:
+    #loadbalancer.opentelekomcloud.com/health-check-protocol: "HTTP"
+    #loadbalancer.opentelekomcloud.com/health-check-url-path: "/healthz"
+    # Bind an existing EIP so the service is reachable from the internet:
+    #loadbalancer.opentelekomcloud.com/eip-ids: "00000000-0000-0000-0000-000000000000"
+    # ...or create (and later release) a dedicated EIP with 100 Mbit/s:
+    #loadbalancer.opentelekomcloud.com/eip-bandwidth: "100"
+spec:
+  type: LoadBalancer
+  selector:
+    app: echo
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+```
+
+After the controller reconciles the Service, `kubectl get service echo` shows
+the load balancer VIP (or EIP, if bound) under `EXTERNAL-IP`.
+
+## Lifecycle
+
+- **Create**: a load balancer named `kube_service_<cluster>_<namespace>_<name>`
+  is created (unless `.../id` points to an existing one), followed by
+  listeners, pools, members and monitors.
+- **Node changes**: members are added/removed to match the current node set.
+- **Port changes**: listeners owned by the Service that no longer match a
+  Service port are removed together with their pool, members and monitor.
+- **Delete**: all owned resources are removed; the load balancer itself is
+  deleted only if it was created by the provider (no `.../id` annotation).
+  An EIP created via `eip-bandwidth` is released as well (OTC only unbinds
+  EIPs on load balancer deletion, which would otherwise leave orphaned,
+  billed EIPs behind); EIPs supplied via `eip-ids` are left untouched.
+
+Mutating calls are retried on `409 Conflict` (load balancer busy) with
+exponential backoff, and the provider waits for the load balancer to return to
+`ACTIVE` provisioning status between steps, so transient errors are handled
+gracefully by the controller's own retry loop.
+
+## Known limitations
+
+- Only `TCP` and `UDP` Service ports are supported (L4 listeners); no
+  TLS termination on the load balancer.
+- Session persistence cannot be switched off on a live pool (`ClientIP` →
+  `None` requires recreating the Service); enabling and tuning it works.
+- With `externalTrafficPolicy: Local`, UDP ports keep a `UDP_CONNECT` probe
+  on the member port – nodes without local endpoints are not excluded for
+  UDP (TCP ports use the kube-proxy healthz port and are excluded properly).
+- The node controllers (Instances API) are not implemented yet: run kubelet
+  without `--cloud-provider=external` and the manager with
+  `--controllers=service` (the shipped manifests do this).
+
+## Deployment
+
+Ready-to-use manifests live in [`manifests/`](../manifests): RBAC, the
+controller Deployment and a `cloud-config` template (create it as a secret in
+`kube-system`). Example workloads are in
+[`examples/loadbalancer/`](../examples/loadbalancer). A container image can be
+built with `make image`.
+
+## Integration tests
+
+`pkg/elb` contains a lifecycle test (`TestLoadBalancerLifecycle`) that runs the
+full create → update → delete flow against an in-process fake of the ELBv3 API
+(`go test ./pkg/elb/...`). It requires no cloud credentials and runs in CI.
+
+Functional (e2e) tests against a real cluster live in
+[`test/e2e/`](../test/e2e) and run via `make test-e2e`; see the README there
+for prerequisites.

--- a/examples/loadbalancer/deployment.yaml
+++ b/examples/loadbalancer/deployment.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-demo
+  labels:
+    app: nginx-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx-demo
+  template:
+    metadata:
+      labels:
+        app: nginx-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27
+          ports:
+            - containerPort: 80

--- a/examples/loadbalancer/service-internal.yaml
+++ b/examples/loadbalancer/service-internal.yaml
@@ -1,0 +1,18 @@
+---
+# Internal load balancer: reachable on the VPC-private VIP only.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-internal
+  annotations:
+    loadbalancer.opentelekomcloud.com/health-check-protocol: "HTTP"
+    loadbalancer.opentelekomcloud.com/health-check-url-path: "/"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-demo
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80

--- a/examples/loadbalancer/service-public-eip.yaml
+++ b/examples/loadbalancer/service-public-eip.yaml
@@ -1,0 +1,20 @@
+---
+# Public load balancer: a dedicated EIP (100 Mbit/s) is created together with
+# the load balancer and released again when the Service is deleted.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-public
+  annotations:
+    loadbalancer.opentelekomcloud.com/eip-bandwidth: "100"
+    loadbalancer.opentelekomcloud.com/idle-timeout: "300"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    app: nginx-demo
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.25.5
 require (
 	github.com/opentelekomcloud/gophertelekomcloud v0.9.5
 	gopkg.in/gcfg.v1 v1.2.3
+	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
+	k8s.io/client-go v0.35.0
 	k8s.io/cloud-provider v0.35.0
 	k8s.io/component-base v0.35.0
 	k8s.io/klog/v2 v2.130.1
@@ -96,10 +98,8 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.0 // indirect
 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
 	k8s.io/apiserver v0.35.0 // indirect
-	k8s.io/client-go v0.35.0 // indirect
 	k8s.io/component-helpers v0.35.0 // indirect
 	k8s.io/controller-manager v0.35.0 // indirect
 	k8s.io/kms v0.35.0 // indirect

--- a/hack/e2e-infra/README.md
+++ b/hack/e2e-infra/README.md
@@ -1,0 +1,48 @@
+# e2e test stand
+
+Disposable single-node k3s cluster on an OTC ECS instance for running the
+functional tests in [`test/e2e`](../../test/e2e). k3s is started with
+`--disable=servicelb --disable-cloud-controller --disable=traefik`, so this
+cloud controller manager is the only thing handling `type: LoadBalancer`
+Services.
+
+Costs while running: one `s3.large.2` ECS + one EIP (a few cents per hour).
+`terraform destroy` removes everything.
+
+## Usage
+
+```sh
+cd hack/e2e-infra
+export OS_CLOUD=<clouds.yaml entry>          # credentials for terraform/tofu
+export SSH_ARGS="-i ~/.ssh/<key>"            # if not your default key
+
+cp terraform.tfvars.example terraform.tfvars # adjust subnet/network IDs
+terraform init                               # OpenTofu works too
+terraform apply
+
+./fetch-kubeconfig.sh                        # waits for k3s, writes ./kubeconfig
+./deploy-ccm.sh                              # cloud-config + CCM deploy
+
+KUBECONFIG=$PWD/kubeconfig make -C ../.. test-e2e
+# The VIP is VPC-private; from outside test through an EIP:
+#   E2E_EIP_BANDWIDTH=10 KUBECONFIG=$PWD/kubeconfig make -C ../.. test-e2e
+
+terraform destroy                            # tear the stand down
+```
+
+`deploy-ccm.sh` deploys in one of two modes (`MODE=image|binary`, default
+depends on docker availability): `image` builds the container for linux/amd64
+and imports it into the node's containerd, deploying the production
+manifests; `binary` cross-compiles the manager and runs it on the node as a
+systemd service – no docker needed. Credentials for the generated
+cloud-config come from `OS_USERNAME`/`OS_PASSWORD` or
+`OS_ACCESS_KEY`/`OS_SECRET_KEY`, with a clouds.yaml fallback (PyYAML
+required); project scope (`project_name`) is picked up as well.
+
+## Notes
+
+- The node's security group allows SSH (22) and the Kubernetes API (6443)
+  from `admin_cidr` (default: everywhere – restrict it in tfvars), plus all
+  TCP/UDP from inside the VPC for LB health checks and NodePorts.
+- kubelet runs without `--cloud-provider=external`: this provider has no
+  Instances API yet, so the CCM only runs the service controller.

--- a/hack/e2e-infra/cloud-init.tftpl
+++ b/hack/e2e-infra/cloud-init.tftpl
@@ -1,0 +1,3 @@
+#cloud-config
+runcmd:
+  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="${k3s_channel}" INSTALL_K3S_EXEC="server --disable=servicelb --disable=traefik --disable-cloud-controller --write-kubeconfig-mode 644 --tls-san ${public_ip}" sh -'

--- a/hack/e2e-infra/deploy-ccm.sh
+++ b/hack/e2e-infra/deploy-ccm.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Builds the cloud controller manager image, imports it into the k3s node's
+# containerd, creates the cloud-config secret and deploys the manifests.
+#
+# Requirements: docker (with buildx), kubectl, terraform outputs available,
+# ./kubeconfig (run fetch-kubeconfig.sh first), and AK/SK credentials in
+# OS_ACCESS_KEY / OS_SECRET_KEY (or a clouds.yaml entry named by OS_CLOUD
+# with ak/sk fields and PyYAML available).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+TF=$(command -v terraform || command -v tofu)
+# Extra ssh options, e.g. SSH_ARGS="-i ~/.ssh/mykey"
+SSH="ssh ${SSH_ARGS:-}"
+IP=$("${TF}" output -raw public_ip)
+SUBNET_ID=$("${TF}" output -raw subnet_id)
+VPC_ID=$("${TF}" output -raw vpc_id)
+AZ=$("${TF}" output -raw availability_zone)
+
+AUTH_URL=${AUTH_URL:-https://iam.eu-de.otc.t-systems.com/v3}
+REGION=${REGION:-eu-de}
+IMAGE=cloud-provider-opentelekomcloud:e2e
+KUBECONFIG_FILE=${KUBECONFIG_FILE:-./kubeconfig}
+KUBECTL="kubectl --kubeconfig=${KUBECONFIG_FILE}"
+
+[ -f "${KUBECONFIG_FILE}" ] || ./fetch-kubeconfig.sh
+
+# --- credentials ---
+# Prefer username/password with project scope from clouds.yaml; fall back to
+# AK/SK from the environment. The generated cloud-config uses whichever is
+# available (the provider itself prefers AK/SK when both are set).
+if [ -z "${OS_USERNAME:-}" ] && [ -z "${OS_ACCESS_KEY:-}" ]; then
+  echo "no credentials in env, reading clouds.yaml (OS_CLOUD=${OS_CLOUD:-})"
+  # Every value is shlex.quote()d: an unquoted secret with spaces or shell
+  # metacharacters would be mangled by eval and its fragments echoed to stderr.
+  eval "$(python3 - <<'EOF'
+import os, shlex, yaml
+path = os.path.expanduser("~/.config/openstack/clouds.yaml")
+cloud = yaml.safe_load(open(path))["clouds"][os.environ["OS_CLOUD"]]
+auth = cloud.get("auth", {})
+def export(name, value):
+    print(f"export {name}={shlex.quote(str(value))}")
+if auth.get("username") and auth.get("password"):
+    export("OS_USERNAME", auth["username"])
+    export("OS_PASSWORD", auth["password"])
+else:
+    ak = cloud.get("ak") or auth.get("ak")
+    sk = cloud.get("sk") or auth.get("sk")
+    if not ak or not sk:
+        raise SystemExit("no usable credentials in clouds.yaml entry")
+    export("OS_ACCESS_KEY", ak)
+    export("OS_SECRET_KEY", sk)
+if auth.get("project_name"):
+    export("OS_PROJECT_NAME", auth["project_name"])
+if auth.get("project_id"):
+    export("OS_PROJECT_ID", auth["project_id"])
+if auth.get("domain_name") or auth.get("user_domain_name"):
+    export("OS_DOMAIN_NAME", auth.get("domain_name") or auth["user_domain_name"])
+EOF
+)"
+fi
+
+# --- cloud-config ---
+CLOUD_CONFIG=$(mktemp)
+trap 'rm -f "${CLOUD_CONFIG}"' EXIT
+cat > "${CLOUD_CONFIG}" <<EOF
+[Global]
+auth-url=${AUTH_URL}
+region=${REGION}
+username=${OS_USERNAME:-}
+password=${OS_PASSWORD:-}
+access-key=${OS_ACCESS_KEY:-}
+secret-key=${OS_SECRET_KEY:-}
+tenant-name=${OS_PROJECT_NAME:-}
+project-id=${OS_PROJECT_ID:-}
+domain-name=${OS_DOMAIN_NAME:-}
+
+[LoadBalancer]
+subnet-id=${SUBNET_ID}
+vpc-id=${VPC_ID}
+availability-zone=${AZ}
+EOF
+
+# MODE=image builds a container image (needs docker) and deploys the
+# manifests; MODE=binary cross-compiles the binary and runs it on the node
+# as a systemd service. Default: image when docker is usable, else binary.
+if [ -z "${MODE:-}" ]; then
+  if docker info >/dev/null 2>&1; then MODE=image; else MODE=binary; fi
+fi
+
+if [ "${MODE}" = "image" ]; then
+  echo ">>> building ${IMAGE} (linux/amd64)"
+  docker buildx build --platform linux/amd64 -t "${IMAGE}" --load ../..
+  echo ">>> importing image into k3s containerd on ${IP}"
+  docker save "${IMAGE}" | ${SSH} "ubuntu@${IP}" 'sudo k3s ctr images import -'
+
+  ${KUBECTL} -n kube-system delete secret cloud-config --ignore-not-found
+  ${KUBECTL} -n kube-system create secret generic cloud-config --from-file=cloud-config="${CLOUD_CONFIG}"
+
+  ${KUBECTL} apply -f ../../manifests/rbac-cloud-controller-manager.yaml
+  sed "s|image: cloud-provider-opentelekomcloud:latest|image: docker.io/library/${IMAGE}|" \
+    ../../manifests/cloud-controller-manager.yaml | ${KUBECTL} apply -f -
+  ${KUBECTL} -n kube-system rollout status deployment/otc-cloud-controller-manager --timeout=180s
+else
+  echo ">>> cross-compiling the controller manager (linux/amd64)"
+  (cd ../.. && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -o hack/e2e-infra/cloud-provider-opentelekomcloud ./cmd/cloud-controller-manager)
+
+  echo ">>> installing binary and systemd unit on ${IP}"
+  scp ${SSH_ARGS:-} ./cloud-provider-opentelekomcloud "ubuntu@${IP}:/tmp/cloud-provider-opentelekomcloud"
+  scp ${SSH_ARGS:-} "${CLOUD_CONFIG}" "ubuntu@${IP}:/tmp/cloud-config"
+  rm -f ./cloud-provider-opentelekomcloud
+  ${SSH} "ubuntu@${IP}" 'sudo bash -s' <<'REMOTE'
+set -euo pipefail
+install -m 0755 /tmp/cloud-provider-opentelekomcloud /usr/local/bin/cloud-provider-opentelekomcloud
+install -m 0600 /tmp/cloud-config /etc/cloud-provider-opentelekomcloud.conf
+rm -f /tmp/cloud-provider-opentelekomcloud /tmp/cloud-config
+cat > /etc/systemd/system/otc-ccm.service <<'UNIT'
+[Unit]
+Description=OTC cloud controller manager (e2e stand)
+After=k3s.service
+[Service]
+ExecStart=/usr/local/bin/cloud-provider-opentelekomcloud \
+  --cloud-provider=opentelekomcloud \
+  --cloud-config=/etc/cloud-provider-opentelekomcloud.conf \
+  --kubeconfig=/etc/rancher/k3s/k3s.yaml \
+  --controllers=service \
+  --leader-elect=false \
+  --v=2
+Restart=always
+RestartSec=5
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable otc-ccm.service
+systemctl restart otc-ccm.service
+sleep 3
+systemctl is-active otc-ccm.service
+REMOTE
+fi
+
+echo ">>> cloud controller manager is running; run the tests with:"
+echo "    KUBECONFIG=$(pwd)/${KUBECONFIG_FILE#./} make -C ../.. test-e2e"

--- a/hack/e2e-infra/fetch-kubeconfig.sh
+++ b/hack/e2e-infra/fetch-kubeconfig.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Fetches the k3s kubeconfig from the test node and rewrites the API address
+# to the node's floating IP. Output: ./kubeconfig
+set -euo pipefail
+cd "$(dirname "$0")"
+
+TF=$(command -v terraform || command -v tofu)
+IP=$("${TF}" output -raw public_ip)
+# Extra ssh options, e.g. SSH_ARGS="-i ~/.ssh/mykey"
+SSH="ssh ${SSH_ARGS:-}"
+
+for i in $(seq 1 30); do
+  if ${SSH} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 "ubuntu@${IP}" \
+    'test -f /etc/rancher/k3s/k3s.yaml' 2>/dev/null; then
+    break
+  fi
+  echo "waiting for k3s on ${IP} (${i}/30)..."
+  sleep 10
+done
+
+${SSH} -o StrictHostKeyChecking=accept-new "ubuntu@${IP}" 'cat /etc/rancher/k3s/k3s.yaml' \
+  | sed "s/127.0.0.1/${IP}/" > kubeconfig
+chmod 600 kubeconfig
+echo "kubeconfig written to $(pwd)/kubeconfig"

--- a/hack/e2e-infra/main.tf
+++ b/hack/e2e-infra/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    opentelekomcloud = {
+      source  = "opentelekomcloud/opentelekomcloud"
+      version = ">= 1.36.0"
+    }
+  }
+}
+
+# Credentials come from clouds.yaml; select the entry with OS_CLOUD.
+provider "opentelekomcloud" {}
+
+resource "opentelekomcloud_networking_floatingip_v2" "node" {
+  pool = "admin_external_net"
+}
+
+resource "opentelekomcloud_compute_keypair_v2" "node" {
+  name       = "${var.prefix}-key"
+  public_key = file(pathexpand(var.ssh_public_key_file))
+}
+
+resource "opentelekomcloud_networking_secgroup_v2" "node" {
+  name        = "${var.prefix}-sg"
+  description = "k3s e2e test node for cloud-provider-opentelekomcloud"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.admin_cidr
+  security_group_id = opentelekomcloud_networking_secgroup_v2.node.id
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "kube_api" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  remote_ip_prefix  = var.admin_cidr
+  security_group_id = opentelekomcloud_networking_secgroup_v2.node.id
+}
+
+# Load balancer health checks and NodePort traffic from inside the VPC.
+resource "opentelekomcloud_networking_secgroup_rule_v2" "vpc_tcp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = var.vpc_cidr
+  security_group_id = opentelekomcloud_networking_secgroup_v2.node.id
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "vpc_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = var.vpc_cidr
+  security_group_id = opentelekomcloud_networking_secgroup_v2.node.id
+}
+
+resource "opentelekomcloud_compute_instance_v2" "node" {
+  name              = "${var.prefix}-node"
+  image_name        = var.image_name
+  flavor_name       = var.flavor_name
+  key_pair          = opentelekomcloud_compute_keypair_v2.node.name
+  availability_zone = var.availability_zone
+  security_groups   = [opentelekomcloud_networking_secgroup_v2.node.name]
+
+  user_data = templatefile("${path.module}/cloud-init.tftpl", {
+    public_ip   = opentelekomcloud_networking_floatingip_v2.node.address
+    k3s_channel = var.k3s_channel
+  })
+
+  network {
+    uuid = var.network_id
+  }
+}
+
+resource "opentelekomcloud_compute_floatingip_associate_v2" "node" {
+  floating_ip = opentelekomcloud_networking_floatingip_v2.node.address
+  instance_id = opentelekomcloud_compute_instance_v2.node.id
+}

--- a/hack/e2e-infra/outputs.tf
+++ b/hack/e2e-infra/outputs.tf
@@ -1,0 +1,27 @@
+output "public_ip" {
+  description = "Floating IP of the k3s node (SSH + Kubernetes API)"
+  value       = opentelekomcloud_networking_floatingip_v2.node.address
+}
+
+output "private_ip" {
+  description = "Private IP of the node inside the VPC"
+  value       = opentelekomcloud_compute_instance_v2.node.access_ip_v4
+}
+
+output "subnet_id" {
+  description = "Neutron subnet ID for the cloud provider [LoadBalancer] section"
+  value       = var.subnet_id
+}
+
+output "vpc_id" {
+  value = var.vpc_id
+}
+
+output "availability_zone" {
+  value = var.availability_zone
+}
+
+output "ssh" {
+  description = "SSH access to the node"
+  value       = "ssh ubuntu@${opentelekomcloud_networking_floatingip_v2.node.address}"
+}

--- a/hack/e2e-infra/terraform.tfvars.example
+++ b/hack/e2e-infra/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# openstack subnet list --long   ->   ID = subnet_id, Network = network_id
+network_id = "a2d7c9f1-7fd9-4943-af53-352538943ab3"
+subnet_id  = "c6e0eba4-17aa-4e16-9522-76a12969deb7"
+# openstack router list (VPC id), optional
+vpc_id = ""
+
+availability_zone = "eu-de-01"
+# Restrict SSH/API access to your IP if desired:
+#admin_cidr = "1.2.3.4/32"

--- a/hack/e2e-infra/variables.tf
+++ b/hack/e2e-infra/variables.tf
@@ -1,0 +1,63 @@
+variable "prefix" {
+  description = "Name prefix for all created resources"
+  type        = string
+  default     = "ccm-e2e"
+}
+
+variable "network_id" {
+  description = "OTC network UUID of the subnet the node attaches to (openstack subnet list, column Network)"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Neutron subnet UUID used by the cloud provider for load balancer VIPs (openstack subnet list, column ID)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC (router) ID, passed through to the cloud provider config"
+  type        = string
+  default     = ""
+}
+
+variable "availability_zone" {
+  description = "AZ for the node and for load balancers"
+  type        = string
+  default     = "eu-de-01"
+}
+
+variable "flavor_name" {
+  description = "ECS flavor for the k3s node"
+  type        = string
+  default     = "s3.large.2"
+}
+
+variable "image_name" {
+  description = "Public image for the node"
+  type        = string
+  default     = "Standard_Ubuntu_24.04_amd64_bios_latest"
+}
+
+variable "k3s_channel" {
+  description = "k3s release channel (stable/latest) or pinned version via INSTALL_K3S_VERSION semantics"
+  type        = string
+  default     = "stable"
+}
+
+variable "ssh_public_key_file" {
+  description = "Path to the SSH public key for node access"
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "admin_cidr" {
+  description = "CIDR allowed to reach SSH (22) and the Kubernetes API (6443)"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR of the VPC, allowed full access to the node (load balancer health checks, NodePorts)"
+  type        = string
+  default     = "10.0.0.0/8"
+}

--- a/manifests/cloud-config
+++ b/manifests/cloud-config
@@ -1,0 +1,34 @@
+# Cloud configuration for the Open Telekom Cloud cloud controller manager.
+#
+# Fill in the values and create the secret before deploying the manager:
+#   kubectl create secret -n kube-system generic cloud-config --from-file=manifests/cloud-config
+#
+# Authentication: either access-key/secret-key (recommended) or
+# username/password. See docs/auth-configuration.md for all options.
+
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+region=eu-de
+domain-name=<OTC domain name, e.g. OTC00000000001000000xxx>
+tenant-name=<project name, e.g. eu-de_myproject>
+# AK/SK auth:
+access-key=<access key>
+secret-key=<secret key>
+# ...or password auth:
+#username=<user name>
+#password=<password>
+
+[LoadBalancer]
+# Neutron subnet ID for the load balancer VIP (required to create LBs).
+subnet-id=<subnet id>
+# VPC (router) ID.
+vpc-id=<vpc id>
+# One or more availability zones for dedicated load balancers.
+availability-zone=eu-de-01
+#availability-zone=eu-de-02
+# Optional defaults, see docs/loadbalancer.md:
+#lb-algorithm=ROUND_ROBIN
+#health-check-enabled=true
+#health-check-delay=5
+#health-check-timeout=3
+#health-check-max-retries=3

--- a/manifests/cloud-controller-manager.yaml
+++ b/manifests/cloud-controller-manager.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otc-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    app: otc-cloud-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otc-cloud-controller-manager
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: otc-cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      hostNetwork: true
+      securityContext:
+        runAsUser: 1001
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+      tolerations:
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: cloud-controller-manager
+          # Replace with the released image of this provider.
+          image: cloud-provider-opentelekomcloud:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - /bin/cloud-provider-opentelekomcloud
+            - --v=2
+            - --cloud-provider=opentelekomcloud
+            - --cloud-config=/etc/config/cloud-config
+            - --use-service-account-credentials=true
+            - --leader-elect=true
+            # Only the service (load balancer) controller is supported for
+            # now; node controllers require the Instances API.
+            - --controllers=service
+          resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/config
+              readOnly: true
+            - name: ca-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: cloud-config
+        - name: ca-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: DirectoryOrCreate

--- a/manifests/rbac-cloud-controller-manager.yaml
+++ b/manifests/rbac-cloud-controller-manager.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+# Scoped to what --controllers=service actually needs (plus leader election
+# and per-controller tokens for --use-service-account-credentials). Enabling
+# the node controllers later will require extending this role.
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - update
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system

--- a/pkg/config/clouds.go
+++ b/pkg/config/clouds.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+)
+
+// AuthOptsFromCloudsYAML loads credentials from a standard clouds.yaml
+// merged with OS_* env vars; the entry is chosen by name or OS_CLOUD.
+// Convenience for CLI/test use – the manager itself uses ReadConfig.
+func AuthOptsFromCloudsYAML(cloudName string) (*AuthOpts, error) {
+	env := openstack.NewEnv("OS_")
+	var (
+		cloud *openstack.Cloud
+		err   error
+	)
+	if cloudName != "" {
+		cloud, err = env.Cloud(cloudName)
+	} else {
+		cloud, err = env.Cloud()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to load clouds.yaml: %w", err)
+	}
+
+	auth := cloud.AuthInfo
+	opts := &AuthOpts{
+		AuthURL:       auth.AuthURL,
+		Username:      auth.Username,
+		Password:      auth.Password,
+		AccessKey:     auth.AccessKey,
+		SecretKey:     auth.SecretKey,
+		SecurityToken: auth.SecurityToken,
+		DomainName:    auth.DomainName,
+		DomainID:      auth.DomainID,
+		TenantName:    auth.ProjectName,
+		ProjectID:     auth.ProjectID,
+		Region:        cloud.RegionName,
+	}
+	if opts.DomainName == "" {
+		opts.DomainName = auth.UserDomainName
+	}
+	if opts.DomainID == "" {
+		opts.DomainID = auth.UserDomainID
+	}
+	if opts.Region == "" && len(cloud.Regions) > 0 {
+		opts.Region = cloud.Regions[0]
+	}
+	// Password-auth scoping uses tenant fields; prefer the project name and
+	// fall back to the project ID to avoid sending both.
+	if opts.TenantName == "" && auth.ProjectID != "" {
+		opts.TenantID = auth.ProjectID
+	}
+
+	if err := validate(opts); err != nil {
+		return nil, fmt.Errorf("clouds.yaml cloud %q: %w", cloud.Cloud, err)
+	}
+	return opts, nil
+}

--- a/pkg/config/clouds_test.go
+++ b/pkg/config/clouds_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testCloudsYAML = `clouds:
+  otc-password:
+    region_name: eu-de
+    auth:
+      auth_url: https://iam.eu-de.otc.t-systems.com/v3
+      username: my-user
+      password: my-password
+      domain_name: OTC000000001
+      project_name: eu-de_project
+  otc-aksk:
+    region_name: eu-nl
+    auth:
+      auth_url: https://iam.eu-nl.otc.t-systems.com/v3
+      ak: my-access-key
+      sk: my-secret-key
+      project_id: pid-123
+      domain_name: OTC000000001
+`
+
+func withCloudsYAML(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clouds.yaml")
+	if err := os.WriteFile(path, []byte(testCloudsYAML), 0o600); err != nil {
+		t.Fatalf("failed to write clouds.yaml: %v", err)
+	}
+	t.Setenv("OS_CLIENT_CONFIG_FILE", path)
+	// Neutralize ambient variables that the SDK env loader (openstack.NewEnv,
+	// gophertelekomcloud loader.go/auth_env.go) would otherwise merge into the
+	// result — including every AK/SK and security-token alias, so a real
+	// credential from the developer's or CI's environment can never end up in
+	// the parsed AuthOpts (or in test output on failure).
+	for _, key := range []string{
+		"OS_CLOUD", "OS_AUTH_URL", "OS_USERNAME", "OS_PASSWORD",
+		"OS_ACCESS_KEY", "OS_SECRET_KEY", "OS_DOMAIN_NAME", "OS_PROJECT_ID",
+		"OS_PROJECT_NAME", "OS_TENANT_NAME", "OS_REGION_NAME",
+		"OS_AK", "OS_SK", "OS_ACCESS_KEY_ID", "OS_ACCESS_KEY_SECRET",
+		"AWS_ACCESS_KEY_ID", "AWS_ACCESS_SECRET_KEY",
+		"OS_SECURITY_TOKEN", "OS_AKSK_SECURITY_TOKEN", "OS_ST", "AWS_SECURITY_TOKEN",
+		"OS_TOKEN", "OS_TOKEN_ID", "OS_PASSCODE",
+		"OS_DOMAIN_ID", "OS_TENANT_ID", "OS_USER_DOMAIN_NAME", "OS_USER_DOMAIN_ID",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestAuthOptsFromCloudsYAML_Password(t *testing.T) {
+	withCloudsYAML(t)
+
+	opts, err := AuthOptsFromCloudsYAML("otc-password")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.AuthMethod() != AuthMethodPassword {
+		t.Errorf("AuthMethod = %q, want %q", opts.AuthMethod(), AuthMethodPassword)
+	}
+	if opts.Username != "my-user" || opts.Password != "my-password" {
+		t.Errorf("unexpected credentials: %+v", opts)
+	}
+	if opts.DomainName != "OTC000000001" || opts.TenantName != "eu-de_project" {
+		t.Errorf("unexpected scope: domain=%q tenant=%q", opts.DomainName, opts.TenantName)
+	}
+	if opts.Region != "eu-de" {
+		t.Errorf("Region = %q, want eu-de", opts.Region)
+	}
+}
+
+func TestAuthOptsFromCloudsYAML_AKSK(t *testing.T) {
+	withCloudsYAML(t)
+
+	opts, err := AuthOptsFromCloudsYAML("otc-aksk")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.AuthMethod() != AuthMethodAKSK {
+		t.Errorf("AuthMethod = %q, want %q", opts.AuthMethod(), AuthMethodAKSK)
+	}
+	if opts.AccessKey != "my-access-key" || opts.SecretKey != "my-secret-key" {
+		t.Errorf("unexpected credentials: %+v", opts)
+	}
+	if opts.ProjectID != "pid-123" || opts.Region != "eu-nl" {
+		t.Errorf("unexpected scope: project=%q region=%q", opts.ProjectID, opts.Region)
+	}
+}
+
+func TestAuthOptsFromCloudsYAML_UnknownCloud(t *testing.T) {
+	withCloudsYAML(t)
+
+	if _, err := AuthOptsFromCloudsYAML("no-such-cloud"); err == nil {
+		t.Error("expected error for unknown cloud entry")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,8 @@ const (
 
 // CloudConfig holds the cloud provider configuration parsed from an INI file.
 type CloudConfig struct {
-	Global AuthOpts
+	Global       AuthOpts
+	LoadBalancer LoadBalancerOpts
 }
 
 // AuthOpts contains authentication and connection options for OTC.
@@ -45,6 +46,59 @@ type AuthOpts struct {
 	TLSInsecure bool   `gcfg:"tls-insecure"`
 }
 
+// LoadBalancerOpts holds ELBv3 defaults; Service annotations override them.
+type LoadBalancerOpts struct {
+	// SubnetID is the neutron subnet ID for the VIP. Required to create LBs.
+	SubnetID string `gcfg:"subnet-id"`
+
+	// VpcID is the VPC (router) ID.
+	VpcID string `gcfg:"vpc-id"`
+
+	// AvailabilityZones for the LB; repeat the key for multiple zones.
+	// Required to create LBs.
+	AvailabilityZones []string `gcfg:"availability-zone"`
+
+	// L4FlavorID is the optional L4 flavor.
+	L4FlavorID string `gcfg:"l4-flavor-id"`
+
+	// LBAlgorithm: ROUND_ROBIN (default), LEAST_CONNECTIONS or SOURCE_IP.
+	LBAlgorithm string `gcfg:"lb-algorithm"`
+
+	// Health monitor defaults: enabled, interval 5s, timeout 3s, 3 retries.
+	HealthCheckEnabled    bool `gcfg:"health-check-enabled"`
+	HealthCheckDelay      int  `gcfg:"health-check-delay"`
+	HealthCheckTimeout    int  `gcfg:"health-check-timeout"`
+	HealthCheckMaxRetries int  `gcfg:"health-check-max-retries"`
+}
+
+// DefaultLoadBalancerOpts returns LoadBalancerOpts pre-filled with defaults.
+func DefaultLoadBalancerOpts() LoadBalancerOpts {
+	return LoadBalancerOpts{
+		LBAlgorithm:           "ROUND_ROBIN",
+		HealthCheckEnabled:    true,
+		HealthCheckDelay:      5,
+		HealthCheckTimeout:    3,
+		HealthCheckMaxRetries: 3,
+	}
+}
+
+// String implements fmt.Stringer and simply leaves the secret fields
+// (Password, SecretKey, SecurityToken) out, so %v/%+v/%s of an AuthOpts —
+// or of any struct embedding it — never prints them. Value receiver on
+// purpose: it covers both AuthOpts and *AuthOpts.
+func (o AuthOpts) String() string {
+	return fmt.Sprintf(
+		"AuthOpts{AuthURL:%q, Username:%q, AccessKey:%q, DomainName:%q, DomainID:%q, "+
+			"TenantID:%q, TenantName:%q, ProjectID:%q, Region:%q, CAFile:%q, TLSInsecure:%t}",
+		o.AuthURL, o.Username, o.AccessKey, o.DomainName, o.DomainID,
+		o.TenantID, o.TenantName, o.ProjectID, o.Region, o.CAFile, o.TLSInsecure)
+}
+
+// GoString implements fmt.GoStringer so %#v doesn't print secrets either.
+func (o AuthOpts) GoString() string {
+	return o.String()
+}
+
 // AuthMethod returns the authentication method based on which credentials are set.
 // Priority: AK/SK > Password.
 func (o *AuthOpts) AuthMethod() string {
@@ -60,7 +114,9 @@ func (o *AuthOpts) AuthMethod() string {
 // ReadConfig parses the cloud configuration from an INI reader, then applies
 // environment variable fallbacks for any unset fields.
 func ReadConfig(cfg io.Reader) (*CloudConfig, error) {
-	cc := &CloudConfig{}
+	cc := &CloudConfig{
+		LoadBalancer: DefaultLoadBalancerOpts(),
+	}
 
 	if cfg != nil {
 		if err := gcfg.FatalOnly(gcfg.ReadInto(cc, cfg)); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,14 +18,29 @@ region=eu-de
 const akskConfig = `
 [Global]
 auth-url=https://iam.eu-de.otc.t-systems.com/v3
-access-key=AKIAIOSFODNN7EXAMPLE
-secret-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+access-key=test-access-key
+secret-key=test-secret-key
 project-id=abc123
 region=eu-de
 domain-name=my-domain
 `
 
+// clearAuthEnv blanks every variable consumed by applyEnvFallbacks so ambient
+// credentials can neither change results nor be printed by failure messages.
+func clearAuthEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"OS_AUTH_URL", "OS_USERNAME", "OS_PASSWORD",
+		"OS_ACCESS_KEY", "OS_SECRET_KEY", "OS_SECURITY_TOKEN",
+		"OS_DOMAIN_NAME", "OS_DOMAIN_ID", "OS_TENANT_ID",
+		"OS_TENANT_NAME", "OS_PROJECT_ID", "OS_REGION_NAME",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestReadConfig_Password(t *testing.T) {
+	clearAuthEnv(t)
 	cc, err := ReadConfig(strings.NewReader(passwordConfig))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -38,7 +53,7 @@ func TestReadConfig_Password(t *testing.T) {
 		t.Errorf("Username = %q, want %q", cc.Global.Username, "my-user")
 	}
 	if cc.Global.Password != "my-password" {
-		t.Errorf("Password = %q, want %q", cc.Global.Password, "my-password")
+		t.Error("Password mismatch")
 	}
 	if cc.Global.AuthMethod() != AuthMethodPassword {
 		t.Errorf("AuthMethod() = %q, want %q", cc.Global.AuthMethod(), AuthMethodPassword)
@@ -46,16 +61,17 @@ func TestReadConfig_Password(t *testing.T) {
 }
 
 func TestReadConfig_AKSK(t *testing.T) {
+	clearAuthEnv(t)
 	cc, err := ReadConfig(strings.NewReader(akskConfig))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if cc.Global.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("AccessKey = %q, want %q", cc.Global.AccessKey, "AKIAIOSFODNN7EXAMPLE")
+	if cc.Global.AccessKey != "test-access-key" {
+		t.Errorf("AccessKey = %q, want %q", cc.Global.AccessKey, "test-access-key")
 	}
-	if cc.Global.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
-		t.Errorf("SecretKey = %q, want %q", cc.Global.SecretKey, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	if cc.Global.SecretKey != "test-secret-key" {
+		t.Error("SecretKey mismatch")
 	}
 	if cc.Global.AuthMethod() != AuthMethodAKSK {
 		t.Errorf("AuthMethod() = %q, want %q", cc.Global.AuthMethod(), AuthMethodAKSK)
@@ -63,6 +79,7 @@ func TestReadConfig_AKSK(t *testing.T) {
 }
 
 func TestReadConfig_EnvFallback(t *testing.T) {
+	clearAuthEnv(t)
 	t.Setenv("OS_AUTH_URL", "https://iam.eu-de.otc.t-systems.com/v3")
 	t.Setenv("OS_ACCESS_KEY", "env-ak")
 	t.Setenv("OS_SECRET_KEY", "env-sk")
@@ -84,6 +101,7 @@ func TestReadConfig_EnvFallback(t *testing.T) {
 }
 
 func TestReadConfig_ConfigOverridesEnv(t *testing.T) {
+	clearAuthEnv(t)
 	t.Setenv("OS_AUTH_URL", "https://env-url/v3")
 	t.Setenv("OS_ACCESS_KEY", "env-ak")
 	t.Setenv("OS_SECRET_KEY", "env-sk")
@@ -96,12 +114,13 @@ func TestReadConfig_ConfigOverridesEnv(t *testing.T) {
 	if cc.Global.AuthURL != "https://iam.eu-de.otc.t-systems.com/v3" {
 		t.Errorf("AuthURL = %q, want config value not env", cc.Global.AuthURL)
 	}
-	if cc.Global.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+	if cc.Global.AccessKey != "test-access-key" {
 		t.Errorf("AccessKey = %q, want config value not env", cc.Global.AccessKey)
 	}
 }
 
 func TestReadConfig_MissingAuthURL(t *testing.T) {
+	clearAuthEnv(t)
 	cfg := `
 [Global]
 username=user
@@ -117,6 +136,7 @@ password=pass
 }
 
 func TestReadConfig_NoCredentials(t *testing.T) {
+	clearAuthEnv(t)
 	cfg := `
 [Global]
 auth-url=https://iam.eu-de.otc.t-systems.com/v3
@@ -140,5 +160,68 @@ func TestAuthOpts_AuthMethod_Priority(t *testing.T) {
 	}
 	if opts.AuthMethod() != AuthMethodAKSK {
 		t.Errorf("AuthMethod() = %q, want %q (AK/SK should take priority)", opts.AuthMethod(), AuthMethodAKSK)
+	}
+}
+
+const lbConfig = `
+[Global]
+auth-url=https://iam.eu-de.otc.t-systems.com/v3
+access-key=ak
+secret-key=sk
+region=eu-de
+
+[LoadBalancer]
+subnet-id=subnet-1234
+vpc-id=vpc-1234
+availability-zone=eu-de-01
+availability-zone=eu-de-02
+l4-flavor-id=flavor-1
+lb-algorithm=LEAST_CONNECTIONS
+health-check-enabled=false
+health-check-delay=10
+`
+
+func TestReadConfig_LoadBalancer(t *testing.T) {
+	cc, err := ReadConfig(strings.NewReader(lbConfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lb := cc.LoadBalancer
+	if lb.SubnetID != "subnet-1234" {
+		t.Errorf("SubnetID = %q, want %q", lb.SubnetID, "subnet-1234")
+	}
+	if lb.VpcID != "vpc-1234" {
+		t.Errorf("VpcID = %q, want %q", lb.VpcID, "vpc-1234")
+	}
+	if len(lb.AvailabilityZones) != 2 || lb.AvailabilityZones[0] != "eu-de-01" || lb.AvailabilityZones[1] != "eu-de-02" {
+		t.Errorf("AvailabilityZones = %v, want [eu-de-01 eu-de-02]", lb.AvailabilityZones)
+	}
+	if lb.L4FlavorID != "flavor-1" {
+		t.Errorf("L4FlavorID = %q, want %q", lb.L4FlavorID, "flavor-1")
+	}
+	if lb.LBAlgorithm != "LEAST_CONNECTIONS" {
+		t.Errorf("LBAlgorithm = %q, want %q", lb.LBAlgorithm, "LEAST_CONNECTIONS")
+	}
+	if lb.HealthCheckEnabled {
+		t.Error("HealthCheckEnabled = true, want false")
+	}
+	if lb.HealthCheckDelay != 10 {
+		t.Errorf("HealthCheckDelay = %d, want 10", lb.HealthCheckDelay)
+	}
+	// Untouched keys keep their defaults.
+	if lb.HealthCheckTimeout != 3 || lb.HealthCheckMaxRetries != 3 {
+		t.Errorf("health check defaults not preserved: timeout=%d retries=%d", lb.HealthCheckTimeout, lb.HealthCheckMaxRetries)
+	}
+}
+
+func TestReadConfig_LoadBalancerDefaults(t *testing.T) {
+	cc, err := ReadConfig(strings.NewReader(akskConfig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lb := cc.LoadBalancer
+	if lb.LBAlgorithm != "ROUND_ROBIN" || !lb.HealthCheckEnabled || lb.HealthCheckDelay != 5 {
+		t.Errorf("unexpected defaults: %+v", lb)
 	}
 }

--- a/pkg/elb/annotations.go
+++ b/pkg/elb/annotations.go
@@ -1,0 +1,237 @@
+package elb
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+// AnnotationPrefix is the common prefix of all Service annotations
+// understood by this cloud provider's load balancer implementation.
+const AnnotationPrefix = "loadbalancer.opentelekomcloud.com/"
+
+// See docs/loadbalancer.md for the full annotation reference.
+const (
+	// AnnotationID reuses an existing load balancer; it is never deleted.
+	AnnotationID = AnnotationPrefix + "id"
+
+	// AnnotationSubnetID overrides the VIP subnet (neutron subnet ID).
+	AnnotationSubnetID = AnnotationPrefix + "subnet-id"
+
+	// AnnotationVpcID overrides the VPC ID.
+	AnnotationVpcID = AnnotationPrefix + "vpc-id"
+
+	// AnnotationAvailabilityZones is a comma-separated AZ list.
+	AnnotationAvailabilityZones = AnnotationPrefix + "availability-zones"
+
+	// AnnotationL4FlavorID overrides the L4 flavor.
+	AnnotationL4FlavorID = AnnotationPrefix + "l4-flavor-id"
+
+	// AnnotationLBAlgorithm overrides the pool algorithm.
+	AnnotationLBAlgorithm = AnnotationPrefix + "lb-algorithm"
+
+	// AnnotationEipIDs binds existing EIPs at creation; never released.
+	AnnotationEipIDs = AnnotationPrefix + "eip-ids"
+
+	// AnnotationEipBandwidth creates an EIP (Mbit/s) with the LB and
+	// releases it on deletion. Mutually exclusive with eip-ids.
+	AnnotationEipBandwidth = AnnotationPrefix + "eip-bandwidth"
+
+	// AnnotationEipType is the created EIP network type. Default "5_bgp".
+	AnnotationEipType = AnnotationPrefix + "eip-type"
+
+	// AnnotationEipKeep keeps the created EIP on deletion.
+	AnnotationEipKeep = AnnotationPrefix + "eip-keep"
+
+	// AnnotationIdleTimeout is the listener idle timeout in seconds.
+	AnnotationIdleTimeout = AnnotationPrefix + "idle-timeout"
+
+	// AnnotationHealthCheckEnabled toggles health monitors.
+	AnnotationHealthCheckEnabled = AnnotationPrefix + "health-check-enabled"
+
+	// AnnotationHealthCheckDelay is the probe interval in seconds.
+	AnnotationHealthCheckDelay = AnnotationPrefix + "health-check-delay"
+
+	// AnnotationHealthCheckTimeout is the probe timeout in seconds.
+	AnnotationHealthCheckTimeout = AnnotationPrefix + "health-check-timeout"
+
+	// AnnotationHealthCheckMaxRetries is the probe retry count.
+	AnnotationHealthCheckMaxRetries = AnnotationPrefix + "health-check-max-retries"
+
+	// AnnotationHealthCheckProtocol is TCP (default), HTTP or HTTPS;
+	// ignored for UDP ports (always UDP_CONNECT).
+	AnnotationHealthCheckProtocol = AnnotationPrefix + "health-check-protocol"
+
+	// AnnotationHealthCheckURLPath is the HTTP(S) probe path.
+	AnnotationHealthCheckURLPath = AnnotationPrefix + "health-check-url-path"
+
+	// AnnotationHealthCheckHTTPMethod is the HTTP(S) probe method.
+	AnnotationHealthCheckHTTPMethod = AnnotationPrefix + "health-check-http-method"
+)
+
+// serviceSettings is the effective load balancer configuration for one
+// Service: cloud config defaults merged with Service annotations.
+type serviceSettings struct {
+	LoadBalancerID    string
+	SubnetID          string
+	VpcID             string
+	AvailabilityZones []string
+	L4FlavorID        string
+	LBAlgorithm       string
+	EipIDs            []string
+	EipBandwidth      int
+	EipType           string
+	EipKeep           bool
+	IdleTimeout       int
+
+	HealthCheckEnabled    bool
+	HealthCheckDelay      int
+	HealthCheckTimeout    int
+	HealthCheckMaxRetries int
+	HealthCheckProtocol   string // "" (TCP), "HTTP" or "HTTPS"
+	HealthCheckURLPath    string
+	HealthCheckHTTPMethod string
+}
+
+// settingsForService merges LoadBalancerOpts defaults with per-Service
+// annotation overrides.
+func settingsForService(defaults config.LoadBalancerOpts, service *v1.Service) (*serviceSettings, error) {
+	s := &serviceSettings{
+		SubnetID:              defaults.SubnetID,
+		VpcID:                 defaults.VpcID,
+		AvailabilityZones:     defaults.AvailabilityZones,
+		L4FlavorID:            defaults.L4FlavorID,
+		LBAlgorithm:           defaults.LBAlgorithm,
+		HealthCheckEnabled:    defaults.HealthCheckEnabled,
+		HealthCheckDelay:      defaults.HealthCheckDelay,
+		HealthCheckTimeout:    defaults.HealthCheckTimeout,
+		HealthCheckMaxRetries: defaults.HealthCheckMaxRetries,
+	}
+	if s.LBAlgorithm == "" {
+		s.LBAlgorithm = "ROUND_ROBIN"
+	}
+
+	ann := service.Annotations
+	if v := ann[AnnotationID]; v != "" {
+		s.LoadBalancerID = v
+	}
+	if v := ann[AnnotationSubnetID]; v != "" {
+		s.SubnetID = v
+	}
+	if v := ann[AnnotationVpcID]; v != "" {
+		s.VpcID = v
+	}
+	if v := ann[AnnotationAvailabilityZones]; v != "" {
+		s.AvailabilityZones = splitTrim(v)
+	}
+	if v := ann[AnnotationL4FlavorID]; v != "" {
+		s.L4FlavorID = v
+	}
+	if v := ann[AnnotationLBAlgorithm]; v != "" {
+		s.LBAlgorithm = v
+	}
+	if v := ann[AnnotationEipIDs]; v != "" {
+		s.EipIDs = splitTrim(v)
+	}
+
+	var err error
+	if s.EipBandwidth, err = annInt(ann, AnnotationEipBandwidth, 0); err != nil {
+		return nil, err
+	}
+	if s.EipBandwidth < 0 {
+		return nil, fmt.Errorf("invalid value %d for annotation %s: must be > 0", s.EipBandwidth, AnnotationEipBandwidth)
+	}
+	if s.EipBandwidth > 0 && len(s.EipIDs) > 0 {
+		return nil, fmt.Errorf("annotations %s and %s are mutually exclusive", AnnotationEipIDs, AnnotationEipBandwidth)
+	}
+	s.EipType = "5_bgp"
+	if v := ann[AnnotationEipType]; v != "" {
+		s.EipType = v
+	}
+	if s.EipKeep, err = annBool(ann, AnnotationEipKeep, false); err != nil {
+		return nil, err
+	}
+	if s.IdleTimeout, err = annInt(ann, AnnotationIdleTimeout, 0); err != nil {
+		return nil, err
+	}
+	if s.IdleTimeout < 0 {
+		return nil, fmt.Errorf("invalid value %d for annotation %s: must be >= 0", s.IdleTimeout, AnnotationIdleTimeout)
+	}
+	if s.HealthCheckEnabled, err = annBool(ann, AnnotationHealthCheckEnabled, s.HealthCheckEnabled); err != nil {
+		return nil, err
+	}
+	if s.HealthCheckDelay, err = annInt(ann, AnnotationHealthCheckDelay, s.HealthCheckDelay); err != nil {
+		return nil, err
+	}
+	if s.HealthCheckTimeout, err = annInt(ann, AnnotationHealthCheckTimeout, s.HealthCheckTimeout); err != nil {
+		return nil, err
+	}
+	if s.HealthCheckMaxRetries, err = annInt(ann, AnnotationHealthCheckMaxRetries, s.HealthCheckMaxRetries); err != nil {
+		return nil, err
+	}
+
+	if v := ann[AnnotationHealthCheckProtocol]; v != "" {
+		proto := strings.ToUpper(v)
+		switch proto {
+		case "TCP", "HTTP", "HTTPS":
+			s.HealthCheckProtocol = proto
+		default:
+			return nil, fmt.Errorf("invalid value %q for annotation %s: must be TCP, HTTP or HTTPS", v, AnnotationHealthCheckProtocol)
+		}
+	}
+	if v := ann[AnnotationHealthCheckURLPath]; v != "" {
+		if !strings.HasPrefix(v, "/") {
+			return nil, fmt.Errorf("invalid value %q for annotation %s: must start with /", v, AnnotationHealthCheckURLPath)
+		}
+		s.HealthCheckURLPath = v
+	}
+	if v := ann[AnnotationHealthCheckHTTPMethod]; v != "" {
+		method := strings.ToUpper(v)
+		switch method {
+		case "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "OPTIONS", "CONNECT", "PATCH":
+			s.HealthCheckHTTPMethod = method
+		default:
+			return nil, fmt.Errorf("invalid value %q for annotation %s: not a valid HTTP method", v, AnnotationHealthCheckHTTPMethod)
+		}
+	}
+
+	return s, nil
+}
+
+func splitTrim(v string) []string {
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func annBool(ann map[string]string, key string, def bool) (bool, error) {
+	v, ok := ann[key]
+	if !ok || v == "" {
+		return def, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def, fmt.Errorf("invalid value %q for annotation %s: %w", v, key, err)
+	}
+	return b, nil
+}
+
+func annInt(ann map[string]string, key string, def int) (int, error) {
+	v, ok := ann[key]
+	if !ok || v == "" {
+		return def, nil
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return def, fmt.Errorf("invalid value %q for annotation %s: %w", v, key, err)
+	}
+	return i, nil
+}

--- a/pkg/elb/annotations_test.go
+++ b/pkg/elb/annotations_test.go
@@ -1,0 +1,170 @@
+package elb
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+func svcWithAnnotations(ann map[string]string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "web",
+			Namespace:   "default",
+			Annotations: ann,
+		},
+	}
+}
+
+func TestSettingsDefaults(t *testing.T) {
+	defaults := config.DefaultLoadBalancerOpts()
+	defaults.SubnetID = "subnet-1"
+	defaults.AvailabilityZones = []string{"eu-de-01"}
+
+	s, err := settingsForService(defaults, svcWithAnnotations(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.SubnetID != "subnet-1" {
+		t.Errorf("expected subnet from config, got %q", s.SubnetID)
+	}
+	if s.LBAlgorithm != "ROUND_ROBIN" {
+		t.Errorf("expected default algorithm, got %q", s.LBAlgorithm)
+	}
+	if !s.HealthCheckEnabled || s.HealthCheckDelay != 5 || s.HealthCheckTimeout != 3 || s.HealthCheckMaxRetries != 3 {
+		t.Errorf("unexpected health check defaults: %+v", s)
+	}
+}
+
+func TestSettingsAnnotationOverrides(t *testing.T) {
+	defaults := config.DefaultLoadBalancerOpts()
+	defaults.SubnetID = "subnet-1"
+
+	s, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationID:                    "lb-1",
+		AnnotationSubnetID:              "subnet-2",
+		AnnotationVpcID:                 "vpc-2",
+		AnnotationAvailabilityZones:     "eu-de-01, eu-de-02",
+		AnnotationL4FlavorID:            "flavor-1",
+		AnnotationLBAlgorithm:           "LEAST_CONNECTIONS",
+		AnnotationEipIDs:                "eip-1,eip-2",
+		AnnotationHealthCheckEnabled:    "false",
+		AnnotationHealthCheckDelay:      "10",
+		AnnotationHealthCheckTimeout:    "9",
+		AnnotationHealthCheckMaxRetries: "7",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if s.LoadBalancerID != "lb-1" || s.SubnetID != "subnet-2" || s.VpcID != "vpc-2" || s.L4FlavorID != "flavor-1" {
+		t.Errorf("unexpected settings: %+v", s)
+	}
+	if !reflect.DeepEqual(s.AvailabilityZones, []string{"eu-de-01", "eu-de-02"}) {
+		t.Errorf("unexpected AZs: %v", s.AvailabilityZones)
+	}
+	if !reflect.DeepEqual(s.EipIDs, []string{"eip-1", "eip-2"}) {
+		t.Errorf("unexpected EIP IDs: %v", s.EipIDs)
+	}
+	if s.LBAlgorithm != "LEAST_CONNECTIONS" {
+		t.Errorf("unexpected algorithm: %q", s.LBAlgorithm)
+	}
+	if s.HealthCheckEnabled || s.HealthCheckDelay != 10 || s.HealthCheckTimeout != 9 || s.HealthCheckMaxRetries != 7 {
+		t.Errorf("unexpected health check settings: %+v", s)
+	}
+}
+
+func TestSettingsInvalidAnnotations(t *testing.T) {
+	defaults := config.DefaultLoadBalancerOpts()
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationHealthCheckEnabled: "not-a-bool",
+	})); err == nil {
+		t.Error("expected error for invalid bool annotation")
+	}
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationHealthCheckDelay: "not-an-int",
+	})); err == nil {
+		t.Error("expected error for invalid int annotation")
+	}
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationHealthCheckProtocol: "GOPHER",
+	})); err == nil {
+		t.Error("expected error for invalid health check protocol")
+	}
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationHealthCheckURLPath: "no-leading-slash",
+	})); err == nil {
+		t.Error("expected error for URL path without leading slash")
+	}
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationHealthCheckHTTPMethod: "FETCH",
+	})); err == nil {
+		t.Error("expected error for invalid HTTP method")
+	}
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationEipBandwidth: "-5",
+	})); err == nil {
+		t.Error("expected error for negative EIP bandwidth")
+	}
+
+	if _, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationEipIDs:       "eip-1",
+		AnnotationEipBandwidth: "100",
+	})); err == nil {
+		t.Error("expected error for mutually exclusive eip-ids and eip-bandwidth")
+	}
+}
+
+func TestSettingsEip(t *testing.T) {
+	defaults := config.DefaultLoadBalancerOpts()
+
+	s, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationEipBandwidth: "500",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.EipBandwidth != 500 {
+		t.Errorf("EipBandwidth = %d, want 500", s.EipBandwidth)
+	}
+	if s.EipType != "5_bgp" {
+		t.Errorf("EipType = %q, want default 5_bgp", s.EipType)
+	}
+
+	s, err = settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationEipBandwidth: "10",
+		AnnotationEipType:      "5_mailbgp",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.EipType != "5_mailbgp" {
+		t.Errorf("EipType = %q, want 5_mailbgp", s.EipType)
+	}
+}
+
+func TestSettingsHTTPHealthCheck(t *testing.T) {
+	defaults := config.DefaultLoadBalancerOpts()
+
+	s, err := settingsForService(defaults, svcWithAnnotations(map[string]string{
+		AnnotationHealthCheckProtocol:   "http",
+		AnnotationHealthCheckURLPath:    "/healthz",
+		AnnotationHealthCheckHTTPMethod: "head",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.HealthCheckProtocol != "HTTP" || s.HealthCheckURLPath != "/healthz" || s.HealthCheckHTTPMethod != "HEAD" {
+		t.Errorf("unexpected health check settings: %+v", s)
+	}
+}

--- a/pkg/elb/elb.go
+++ b/pkg/elb/elb.go
@@ -1,0 +1,915 @@
+// Package elb implements the cloudprovider.LoadBalancer interface on top of
+// the Open Telekom Cloud ELBv3 (dedicated load balancer) API.
+package elb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/listeners"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/loadbalancers"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/members"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/monitors"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/pools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/eips"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/identity"
+)
+
+const (
+	// lbNamePrefix follows the OpenStack cloud provider naming convention.
+	lbNamePrefix = "kube_service"
+
+	maxResourceNameLength = 255
+
+	statusActive = "ACTIVE"
+	statusError  = "ERROR"
+
+	activePollInterval = 3 * time.Second
+	activePollTimeout  = 5 * time.Minute
+)
+
+// LoadBalancer manages OTC ELBv3 load balancers for Kubernetes Services.
+type LoadBalancer struct {
+	opts config.LoadBalancerOpts
+
+	// newClient builds an ELBv3 service client. Overridable in tests.
+	newClient func(ctx context.Context) (*golangsdk.ServiceClient, error)
+
+	// newNetworkClient builds a VPC/network v1 service client (EIP API).
+	// Overridable in tests.
+	newNetworkClient func(ctx context.Context) (*golangsdk.ServiceClient, error)
+}
+
+// NewLoadBalancer creates a LoadBalancer. The identity getter is evaluated
+// per call so a later token-cache wrapper is picked up.
+func NewLoadBalancer(getIdentity func() identity.IdentityProvider, opts config.LoadBalancerOpts) *LoadBalancer {
+	return &LoadBalancer{
+		opts: opts,
+		newClient: func(ctx context.Context) (*golangsdk.ServiceClient, error) {
+			id := getIdentity()
+			client, err := id.GetServiceClient(ctx, identity.ServiceELBv3, golangsdk.EndpointOpts{Region: id.Region()})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create ELBv3 client: %w", err)
+			}
+			return client, nil
+		},
+		newNetworkClient: func(ctx context.Context) (*golangsdk.ServiceClient, error) {
+			id := getIdentity()
+			client, err := id.GetServiceClient(ctx, identity.ServiceNetworkV1, golangsdk.EndpointOpts{Region: id.Region()})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create network client: %w", err)
+			}
+			return client, nil
+		},
+	}
+}
+
+// GetLoadBalancerName follows the OpenStack provider naming convention.
+func (lb *LoadBalancer) GetLoadBalancerName(_ context.Context, clusterName string, service *v1.Service) string {
+	name := fmt.Sprintf("%s_%s_%s_%s", lbNamePrefix, clusterName, service.Namespace, service.Name)
+	return cutString(name, maxResourceNameLength)
+}
+
+// GetLoadBalancer returns the load balancer status if it exists.
+func (lb *LoadBalancer) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
+	settings, err := settingsForService(lb.opts, service)
+	if err != nil {
+		return nil, false, err
+	}
+	client, err := lb.newClient(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	balancer, err := lb.findLoadBalancer(client, settings, lb.GetLoadBalancerName(ctx, clusterName, service))
+	if err != nil {
+		return nil, false, err
+	}
+	if balancer == nil {
+		return nil, false, nil
+	}
+	return lbStatus(balancer), true, nil
+}
+
+// EnsureLoadBalancer reconciles the LB and all its sub-resources.
+func (lb *LoadBalancer) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+	if len(service.Spec.Ports) == 0 {
+		return nil, fmt.Errorf("no ports provided for load balancer service %s/%s", service.Namespace, service.Name)
+	}
+	if err := validatePorts(service); err != nil {
+		return nil, err
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no nodes available for load balancer service %s/%s", service.Namespace, service.Name)
+	}
+
+	settings, err := settingsForService(lb.opts, service)
+	if err != nil {
+		return nil, err
+	}
+	client, err := lb.newClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	name := lb.GetLoadBalancerName(ctx, clusterName, service)
+	balancer, err := lb.findLoadBalancer(client, settings, name)
+	if err != nil {
+		return nil, err
+	}
+	if balancer == nil {
+		if settings.LoadBalancerID != "" {
+			return nil, fmt.Errorf("load balancer %q referenced by annotation %s not found", settings.LoadBalancerID, AnnotationID)
+		}
+		balancer, err = lb.createLoadBalancer(client, settings, name, service)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("Created load balancer %s (%s) for service %s/%s", balancer.Name, balancer.ID, service.Namespace, service.Name)
+	}
+
+	if err := waitForActive(ctx, client, balancer.ID); err != nil {
+		return nil, err
+	}
+
+	if err := lb.reconcile(ctx, client, balancer, name, settings, service, nodes); err != nil {
+		return nil, err
+	}
+
+	// Re-read for fresh EIP/VIP data.
+	balancer, err = loadbalancers.Get(client, balancer.ID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get load balancer after reconcile: %w", err)
+	}
+	return lbStatus(balancer), nil
+}
+
+// UpdateLoadBalancer reconciles pool members after the node set changed.
+func (lb *LoadBalancer) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	settings, err := settingsForService(lb.opts, service)
+	if err != nil {
+		return err
+	}
+	client, err := lb.newClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	name := lb.GetLoadBalancerName(ctx, clusterName, service)
+	balancer, err := lb.findLoadBalancer(client, settings, name)
+	if err != nil {
+		return err
+	}
+	if balancer == nil {
+		return fmt.Errorf("load balancer for service %s/%s not found", service.Namespace, service.Name)
+	}
+
+	existing, err := listListeners(client, balancer.ID)
+	if err != nil {
+		return err
+	}
+	byKey := listenersByKey(existing)
+
+	for _, port := range service.Spec.Ports {
+		listener, ok := byKey[portKey(port)]
+		if !ok {
+			return fmt.Errorf("listener for port %s/%d of service %s/%s not found", port.Protocol, port.Port, service.Namespace, service.Name)
+		}
+		pool, err := findPoolForListener(client, listener.ID)
+		if err != nil {
+			return err
+		}
+		if pool == nil {
+			return fmt.Errorf("pool for listener %s not found", listener.ID)
+		}
+		if err := lb.reconcileMembers(ctx, client, balancer, pool.ID, port.NodePort, nodes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnsureLoadBalancerDeleted removes everything this Service owns; a shared
+// LB (id annotation) itself is kept.
+func (lb *LoadBalancer) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	settings, err := settingsForService(lb.opts, service)
+	if err != nil {
+		return err
+	}
+	client, err := lb.newClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	name := lb.GetLoadBalancerName(ctx, clusterName, service)
+	balancer, err := lb.findLoadBalancer(client, settings, name)
+	if err != nil {
+		return err
+	}
+	if balancer == nil {
+		return nil
+	}
+
+	shared := settings.LoadBalancerID != ""
+
+	existing, err := listListeners(client, balancer.ID)
+	if err != nil {
+		return err
+	}
+	for i := range existing {
+		listener := &existing[i]
+		if shared && !strings.HasPrefix(listener.Name, name+"_") {
+			continue // not ours
+		}
+		if err := lb.deleteListener(ctx, client, balancer.ID, name, listener); err != nil {
+			return err
+		}
+	}
+
+	if shared {
+		return nil
+	}
+
+	// No waitForActive here: the load balancer is gone after this call.
+	if err := retryOnConflict(ctx, balancer.ID, func() error {
+		return loadbalancers.Delete(client, balancer.ID).ExtractErr()
+	}); err != nil && !isNotFound(err) {
+		return fmt.Errorf("failed to delete load balancer %s: %w", balancer.ID, err)
+	}
+	klog.V(2).Infof("Deleted load balancer %s (%s) for service %s/%s", name, balancer.ID, service.Namespace, service.Name)
+
+	// OTC only unbinds EIPs on LB deletion; release auto-created ones so
+	// they do not leak (user-provided eip-ids are never touched).
+	if settings.EipBandwidth > 0 && !settings.EipKeep {
+		if err := lb.releaseEips(ctx, balancer.PublicIps); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// releaseEips releases EIPs, retrying while unbinding is in progress.
+func (lb *LoadBalancer) releaseEips(ctx context.Context, eipInfos []loadbalancers.PublicIpInfo) error {
+	if len(eipInfos) == 0 {
+		return nil
+	}
+	netClient, err := lb.newNetworkClient(ctx)
+	if err != nil {
+		return err
+	}
+	for _, eip := range eipInfos {
+		if eip.PublicIpID == "" {
+			continue
+		}
+		err := retryOnConflict(ctx, eip.PublicIpID, func() error {
+			if err := eips.Delete(netClient, eip.PublicIpID).ExtractErr(); err != nil {
+				// A still-bound EIP surfaces as 400/409; retry those too.
+				if isConflict(err) || isBadRequest(err) {
+					return golangsdk.ErrDefault409{}
+				}
+				return err
+			}
+			return nil
+		})
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("failed to release EIP %s (%s): %w", eip.PublicIpID, eip.PublicIpAddress, err)
+		}
+		klog.V(2).Infof("Released EIP %s (%s)", eip.PublicIpID, eip.PublicIpAddress)
+	}
+	return nil
+}
+
+// --- reconciliation ---
+
+// reconcile drives listeners, pools, members and monitors to the desired state.
+func (lb *LoadBalancer) reconcile(ctx context.Context, client *golangsdk.ServiceClient, balancer *loadbalancers.LoadBalancer, name string, settings *serviceSettings, service *v1.Service, nodes []*v1.Node) error {
+	existing, err := listListeners(client, balancer.ID)
+	if err != nil {
+		return err
+	}
+	byKey := listenersByKey(existing)
+
+	wanted := map[string]bool{}
+	for _, port := range service.Spec.Ports {
+		key := portKey(port)
+		wanted[key] = true
+
+		listener, ok := byKey[key]
+		if !ok {
+			created, err := lb.createListener(ctx, client, balancer.ID, name, settings, port)
+			if err != nil {
+				return err
+			}
+			listener = *created
+			klog.V(2).Infof("Created listener %s (%s)", listener.Name, listener.ID)
+		} else if settings.IdleTimeout > 0 {
+			// The SDK does not expose the current value; apply unconditionally.
+			err := mutate(ctx, client, balancer.ID, func() error {
+				_, err := listeners.Update(client, listener.ID, listeners.UpdateOpts{
+					KeepAliveTimeout: settings.IdleTimeout,
+				}).Extract()
+				return err
+			})
+			if err != nil {
+				return fmt.Errorf("failed to update listener %s: %w", listener.ID, err)
+			}
+		}
+
+		if err := lb.reconcileIPGroup(ctx, client, balancer.ID, &listener, name, service, port); err != nil {
+			return err
+		}
+
+		pool, err := lb.ensurePool(ctx, client, balancer.ID, listener, name, settings, service, port)
+		if err != nil {
+			return err
+		}
+
+		if err := lb.reconcileMembers(ctx, client, balancer, pool.ID, port.NodePort, nodes); err != nil {
+			return err
+		}
+
+		if err := lb.reconcileMonitor(ctx, client, balancer.ID, pool, name, settings, service, port); err != nil {
+			return err
+		}
+	}
+
+	// Remove listeners we own that no longer match a Service port.
+	for i := range existing {
+		listener := &existing[i]
+		if !strings.HasPrefix(listener.Name, name+"_") {
+			continue
+		}
+		if wanted[listenerKey(listener)] {
+			continue
+		}
+		klog.V(2).Infof("Deleting stale listener %s (%s)", listener.Name, listener.ID)
+		if err := lb.deleteListener(ctx, client, balancer.ID, name, listener); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (lb *LoadBalancer) createLoadBalancer(client *golangsdk.ServiceClient, settings *serviceSettings, name string, service *v1.Service) (*loadbalancers.LoadBalancer, error) {
+	if settings.SubnetID == "" {
+		return nil, fmt.Errorf("cannot create load balancer for service %s/%s: subnet-id is not set (config [LoadBalancer] subnet-id or annotation %s)",
+			service.Namespace, service.Name, AnnotationSubnetID)
+	}
+	if len(settings.AvailabilityZones) == 0 {
+		return nil, fmt.Errorf("cannot create load balancer for service %s/%s: no availability zones set (config [LoadBalancer] availability-zone or annotation %s)",
+			service.Namespace, service.Name, AnnotationAvailabilityZones)
+	}
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:                 name,
+		Description:          fmt.Sprintf("Kubernetes service %s/%s", service.Namespace, service.Name),
+		VipSubnetCidrID:      settings.SubnetID,
+		VpcID:                settings.VpcID,
+		AvailabilityZoneList: settings.AvailabilityZones,
+		L4Flavor:             settings.L4FlavorID,
+		VipAddress:           service.Spec.LoadBalancerIP, //nolint:staticcheck // deprecated field still honored
+		PublicIpIDs:          settings.EipIDs,
+	}
+	if settings.EipBandwidth > 0 {
+		createOpts.PublicIp = &loadbalancers.PublicIp{
+			NetworkType: settings.EipType,
+			Description: fmt.Sprintf("Kubernetes service %s/%s", service.Namespace, service.Name),
+			Bandwidth: loadbalancers.Bandwidth{
+				Name:       cutString(name, 64),
+				Size:       settings.EipBandwidth,
+				ChargeMode: "traffic",
+				ShareType:  "PER",
+			},
+		}
+	}
+
+	balancer, err := loadbalancers.Create(client, createOpts).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create load balancer: %w", err)
+	}
+	return balancer, nil
+}
+
+func (lb *LoadBalancer) createListener(ctx context.Context, client *golangsdk.ServiceClient, lbID, name string, settings *serviceSettings, port v1.ServicePort) (*listeners.Listener, error) {
+	var listener *listeners.Listener
+	err := mutate(ctx, client, lbID, func() error {
+		var err error
+		listener, err = listeners.Create(client, listeners.CreateOpts{
+			LoadbalancerID:   lbID,
+			Name:             cutString(fmt.Sprintf("%s_%s_%d", name, port.Protocol, port.Port), maxResourceNameLength),
+			Protocol:         listeners.Protocol(port.Protocol),
+			ProtocolPort:     int(port.Port),
+			KeepAliveTimeout: settings.IdleTimeout,
+		}).Extract()
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener for port %d: %w", port.Port, err)
+	}
+	return listener, nil
+}
+
+// desiredPersistence maps Service session affinity to pool persistence.
+func desiredPersistence(service *v1.Service) *pools.SessionPersistence {
+	if service.Spec.SessionAffinity != v1.ServiceAffinityClientIP {
+		return nil
+	}
+	persistence := &pools.SessionPersistence{Type: "SOURCE_IP"}
+	if cfg := service.Spec.SessionAffinityConfig; cfg != nil && cfg.ClientIP != nil && cfg.ClientIP.TimeoutSeconds != nil {
+		// ELB wants minutes (1-60), Kubernetes gives seconds; round up and clamp.
+		minutes := int((*cfg.ClientIP.TimeoutSeconds + 59) / 60)
+		if minutes < 1 {
+			minutes = 1
+		}
+		if minutes > 60 {
+			minutes = 60
+		}
+		persistence.PersistenceTimeout = minutes
+	}
+	return persistence
+}
+
+func persistenceEqual(a, b *pools.SessionPersistence) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Type == b.Type && a.PersistenceTimeout == b.PersistenceTimeout
+}
+
+// ensurePool creates or reconciles the listener's default pool.
+func (lb *LoadBalancer) ensurePool(ctx context.Context, client *golangsdk.ServiceClient, lbID string, listener listeners.Listener, name string, settings *serviceSettings, service *v1.Service, port v1.ServicePort) (*pools.Pool, error) {
+	persistence := desiredPersistence(service)
+
+	if listener.DefaultPoolID != "" {
+		pool, err := pools.Get(client, listener.DefaultPoolID).Extract()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pool %s: %w", listener.DefaultPoolID, err)
+		}
+		if persistence == nil && pool.Persistence != nil {
+			// The SDK cannot send an explicit null to clear persistence.
+			klog.Warningf("Cannot disable session persistence on existing pool %s; recreate the Service to remove it", pool.ID)
+		}
+		if pool.LBMethod != settings.LBAlgorithm || (persistence != nil && !persistenceEqual(pool.Persistence, persistence)) {
+			updateOpts := pools.UpdateOpts{
+				LBMethod:    settings.LBAlgorithm,
+				Persistence: persistence,
+			}
+			err := mutate(ctx, client, lbID, func() error {
+				var err error
+				pool, err = pools.Update(client, pool.ID, updateOpts).Extract()
+				return err
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to update pool %s: %w", pool.ID, err)
+			}
+			klog.V(2).Infof("Updated pool %s (%s)", pool.Name, pool.ID)
+		}
+		return pool, nil
+	}
+
+	createOpts := pools.CreateOpts{
+		ListenerID:  listener.ID,
+		Name:        cutString(fmt.Sprintf("%s_%s_%d", name, port.Protocol, port.Port), maxResourceNameLength),
+		Protocol:    string(port.Protocol),
+		LBMethod:    settings.LBAlgorithm,
+		Description: fmt.Sprintf("Kubernetes service %s/%s", service.Namespace, service.Name),
+		Persistence: persistence,
+	}
+
+	var pool *pools.Pool
+	err := mutate(ctx, client, lbID, func() error {
+		var err error
+		pool, err = pools.Create(client, createOpts).Extract()
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pool for listener %s: %w", listener.ID, err)
+	}
+	klog.V(2).Infof("Created pool %s (%s)", pool.Name, pool.ID)
+	return pool, nil
+}
+
+// reconcileMembers syncs pool members with the node set on the NodePort.
+func (lb *LoadBalancer) reconcileMembers(ctx context.Context, client *golangsdk.ServiceClient, balancer *loadbalancers.LoadBalancer, poolID string, nodePort int32, nodes []*v1.Node) error {
+	if nodePort == 0 {
+		return fmt.Errorf("service has no NodePort allocated; cannot add members to pool %s", poolID)
+	}
+
+	existing, err := listMembers(client, poolID)
+	if err != nil {
+		return err
+	}
+
+	wanted := map[string]*v1.Node{}
+	for _, node := range nodes {
+		addr, err := nodeAddress(node)
+		if err != nil {
+			klog.Warningf("Skipping node %s: %v", node.Name, err)
+			continue
+		}
+		wanted[fmt.Sprintf("%s:%d", addr, nodePort)] = node
+	}
+	if len(wanted) == 0 {
+		return fmt.Errorf("no usable node addresses for pool %s", poolID)
+	}
+
+	have := map[string]string{} // addr:port -> member ID
+	for _, m := range existing {
+		have[fmt.Sprintf("%s:%d", m.Address, m.ProtocolPort)] = m.ID
+	}
+
+	for key, node := range wanted {
+		if _, ok := have[key]; ok {
+			continue
+		}
+		addr, _ := nodeAddress(node)
+		err := mutate(ctx, client, balancer.ID, func() error {
+			_, err := members.Create(client, poolID, members.CreateOpts{
+				Address:      addr,
+				ProtocolPort: int(nodePort),
+				Name:         cutString(node.Name, maxResourceNameLength),
+				SubnetID:     balancer.VipSubnetCidrID,
+			}).Extract()
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add member %s to pool %s: %w", key, poolID, err)
+		}
+		klog.V(2).Infof("Added member %s to pool %s", key, poolID)
+	}
+
+	for key, id := range have {
+		if _, ok := wanted[key]; ok {
+			continue
+		}
+		err := mutate(ctx, client, balancer.ID, func() error {
+			return members.Delete(client, poolID, id).ExtractErr()
+		})
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("failed to remove member %s from pool %s: %w", key, poolID, err)
+		}
+		klog.V(2).Infof("Removed member %s from pool %s", key, poolID)
+	}
+	return nil
+}
+
+// reconcileMonitor creates, updates or deletes the pool's health monitor.
+func (lb *LoadBalancer) reconcileMonitor(ctx context.Context, client *golangsdk.ServiceClient, lbID string, pool *pools.Pool, name string, settings *serviceSettings, service *v1.Service, port v1.ServicePort) error {
+	monitorType := monitors.TypeTCP
+	monitorPort := 0
+	urlPath := ""
+	httpMethod := ""
+	switch {
+	case port.Protocol == v1.ProtocolUDP:
+		// The SDK has no constant for UDP_CONNECT yet.
+		monitorType = monitors.Type("UDP_CONNECT")
+	case service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyLocal && service.Spec.HealthCheckNodePort > 0:
+		// Local policy: probe kube-proxy healthz so only nodes with local
+		// endpoints receive traffic.
+		monitorType = monitors.TypeHTTP
+		monitorPort = int(service.Spec.HealthCheckNodePort)
+		urlPath = "/healthz"
+		httpMethod = "GET"
+	case settings.HealthCheckProtocol == "HTTP" || settings.HealthCheckProtocol == "HTTPS":
+		monitorType = monitors.Type(settings.HealthCheckProtocol)
+		urlPath = settings.HealthCheckURLPath
+		if urlPath == "" {
+			urlPath = "/"
+		}
+		httpMethod = settings.HealthCheckHTTPMethod
+		if httpMethod == "" {
+			httpMethod = "GET"
+		}
+	}
+
+	if !settings.HealthCheckEnabled {
+		if pool.MonitorID == "" {
+			return nil
+		}
+		err := mutate(ctx, client, lbID, func() error {
+			return monitors.Delete(client, pool.MonitorID).ExtractErr()
+		})
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("failed to delete monitor %s: %w", pool.MonitorID, err)
+		}
+		klog.V(2).Infof("Deleted health monitor %s of pool %s", pool.MonitorID, pool.ID)
+		return nil
+	}
+
+	createMonitor := func() error {
+		err := mutate(ctx, client, lbID, func() error {
+			_, err := monitors.Create(client, monitors.CreateOpts{
+				PoolID:      pool.ID,
+				Name:        cutString(fmt.Sprintf("%s_%s_%d", name, port.Protocol, port.Port), maxResourceNameLength),
+				Type:        monitorType,
+				Delay:       settings.HealthCheckDelay,
+				Timeout:     settings.HealthCheckTimeout,
+				MaxRetries:  settings.HealthCheckMaxRetries,
+				URLPath:     urlPath,
+				HTTPMethod:  httpMethod,
+				MonitorPort: monitorPort,
+			}).Extract()
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create monitor for pool %s: %w", pool.ID, err)
+		}
+		klog.V(2).Infof("Created health monitor for pool %s", pool.ID)
+		return nil
+	}
+
+	if pool.MonitorID == "" {
+		return createMonitor()
+	}
+
+	monitor, err := monitors.Get(client, pool.MonitorID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get monitor %s: %w", pool.MonitorID, err)
+	}
+	if monitor.Type != monitorType || monitor.MonitorPort != monitorPort {
+		// Port cannot be reset via update; recreate on type/port changes.
+		err := mutate(ctx, client, lbID, func() error {
+			return monitors.Delete(client, pool.MonitorID).ExtractErr()
+		})
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("failed to delete monitor %s for recreation: %w", pool.MonitorID, err)
+		}
+		return createMonitor()
+	}
+	if monitor.Delay == settings.HealthCheckDelay &&
+		monitor.Timeout == settings.HealthCheckTimeout &&
+		monitor.MaxRetries == settings.HealthCheckMaxRetries &&
+		monitor.URLPath == urlPath &&
+		monitor.HTTPMethod == httpMethod {
+		return nil
+	}
+	err = mutate(ctx, client, lbID, func() error {
+		_, err := monitors.Update(client, pool.MonitorID, monitors.UpdateOpts{
+			Delay:      settings.HealthCheckDelay,
+			Timeout:    settings.HealthCheckTimeout,
+			MaxRetries: settings.HealthCheckMaxRetries,
+			URLPath:    urlPath,
+			HTTPMethod: httpMethod,
+		}).Extract()
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update monitor %s: %w", pool.MonitorID, err)
+	}
+	klog.V(2).Infof("Updated health monitor %s of pool %s", pool.MonitorID, pool.ID)
+	return nil
+}
+
+// deleteListener tears down a listener with its pool, members, monitor and
+// owned IP group.
+func (lb *LoadBalancer) deleteListener(ctx context.Context, client *golangsdk.ServiceClient, lbID, name string, listener *listeners.Listener) error {
+	pool, err := findPoolForListener(client, listener.ID)
+	if err != nil {
+		return err
+	}
+	if pool != nil {
+		if pool.MonitorID != "" {
+			err := mutate(ctx, client, lbID, func() error {
+				return monitors.Delete(client, pool.MonitorID).ExtractErr()
+			})
+			if err != nil && !isNotFound(err) {
+				return fmt.Errorf("failed to delete monitor %s: %w", pool.MonitorID, err)
+			}
+		}
+		existing, err := listMembers(client, pool.ID)
+		if err != nil {
+			return err
+		}
+		for _, m := range existing {
+			err := mutate(ctx, client, lbID, func() error {
+				return members.Delete(client, pool.ID, m.ID).ExtractErr()
+			})
+			if err != nil && !isNotFound(err) {
+				return fmt.Errorf("failed to delete member %s: %w", m.ID, err)
+			}
+		}
+		err = mutate(ctx, client, lbID, func() error {
+			return pools.Delete(client, pool.ID).ExtractErr()
+		})
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("failed to delete pool %s: %w", pool.ID, err)
+		}
+	}
+
+	err = mutate(ctx, client, lbID, func() error {
+		return listeners.Delete(client, listener.ID).ExtractErr()
+	})
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("failed to delete listener %s: %w", listener.ID, err)
+	}
+	// The group can only be deleted once the listener no longer binds it.
+	return lb.deleteIPGroup(ctx, client, lbID, listener.IpGroup.IpGroupID, name)
+}
+
+// --- lookup helpers ---
+
+// findLoadBalancer looks up the LB by id annotation or name; nil if absent.
+func (lb *LoadBalancer) findLoadBalancer(client *golangsdk.ServiceClient, settings *serviceSettings, name string) (*loadbalancers.LoadBalancer, error) {
+	if settings.LoadBalancerID != "" {
+		balancer, err := loadbalancers.Get(client, settings.LoadBalancerID).Extract()
+		if err != nil {
+			if isNotFound(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to get load balancer %s: %w", settings.LoadBalancerID, err)
+		}
+		return balancer, nil
+	}
+
+	pages, err := loadbalancers.List(client, loadbalancers.ListOpts{Name: []string{name}}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list load balancers: %w", err)
+	}
+	items, err := loadbalancers.ExtractLoadbalancers(pages)
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		if items[i].Name == name {
+			return &items[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func findPoolForListener(client *golangsdk.ServiceClient, listenerID string) (*pools.Pool, error) {
+	listener, err := listeners.Get(client, listenerID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get listener %s: %w", listenerID, err)
+	}
+	if listener.DefaultPoolID == "" {
+		return nil, nil
+	}
+	pool, err := pools.Get(client, listener.DefaultPoolID).Extract()
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get pool %s: %w", listener.DefaultPoolID, err)
+	}
+	return pool, nil
+}
+
+func listListeners(client *golangsdk.ServiceClient, lbID string) ([]listeners.Listener, error) {
+	pages, err := listeners.List(client, listeners.ListOpts{LoadBalancerID: []string{lbID}}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list listeners of load balancer %s: %w", lbID, err)
+	}
+	return listeners.ExtractListeners(pages)
+}
+
+func listMembers(client *golangsdk.ServiceClient, poolID string) ([]members.Member, error) {
+	pages, err := members.List(client, poolID, members.ListOpts{}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list members of pool %s: %w", poolID, err)
+	}
+	return members.ExtractMembers(pages)
+}
+
+// --- small helpers ---
+
+func portKey(port v1.ServicePort) string {
+	return fmt.Sprintf("%s/%d", port.Protocol, port.Port)
+}
+
+func listenerKey(listener *listeners.Listener) string {
+	return fmt.Sprintf("%s/%d", listener.Protocol, listener.ProtocolPort)
+}
+
+func listenersByKey(items []listeners.Listener) map[string]listeners.Listener {
+	m := make(map[string]listeners.Listener, len(items))
+	for _, l := range items {
+		m[listenerKey(&l)] = l
+	}
+	return m
+}
+
+func validatePorts(service *v1.Service) error {
+	for _, port := range service.Spec.Ports {
+		switch port.Protocol {
+		case v1.ProtocolTCP, v1.ProtocolUDP:
+		default:
+			return fmt.Errorf("protocol %s of port %d is not supported by ELB (only TCP and UDP)", port.Protocol, port.Port)
+		}
+	}
+	return nil
+}
+
+// nodeAddress returns the member address, preferring the internal IP.
+func nodeAddress(node *v1.Node) (string, error) {
+	var external string
+	for _, addr := range node.Status.Addresses {
+		switch addr.Type {
+		case v1.NodeInternalIP:
+			if addr.Address != "" {
+				return addr.Address, nil
+			}
+		case v1.NodeExternalIP:
+			if external == "" {
+				external = addr.Address
+			}
+		}
+	}
+	if external != "" {
+		return external, nil
+	}
+	return "", fmt.Errorf("node %s has no internal or external IP address", node.Name)
+}
+
+// lbStatus builds the Service status, preferring EIPs over the private VIP.
+func lbStatus(balancer *loadbalancers.LoadBalancer) *v1.LoadBalancerStatus {
+	status := &v1.LoadBalancerStatus{}
+	for _, eip := range balancer.PublicIps {
+		if eip.PublicIpAddress != "" {
+			status.Ingress = append(status.Ingress, v1.LoadBalancerIngress{IP: eip.PublicIpAddress})
+		}
+	}
+	if len(status.Ingress) == 0 && balancer.VipAddress != "" {
+		status.Ingress = append(status.Ingress, v1.LoadBalancerIngress{IP: balancer.VipAddress})
+	}
+	return status
+}
+
+func cutString(s string, length int) string {
+	if len(s) > length {
+		return s[:length]
+	}
+	return s
+}
+
+// waitForActive polls until the LB provisioning status is ACTIVE.
+func waitForActive(ctx context.Context, client *golangsdk.ServiceClient, lbID string) error {
+	return wait.PollUntilContextTimeout(ctx, activePollInterval, activePollTimeout, true, func(_ context.Context) (bool, error) {
+		balancer, err := loadbalancers.Get(client, lbID).Extract()
+		if err != nil {
+			return false, err
+		}
+		switch balancer.ProvisioningStatus {
+		case statusActive:
+			return true, nil
+		case statusError:
+			return false, fmt.Errorf("load balancer %s is in ERROR state", lbID)
+		default:
+			return false, nil
+		}
+	})
+}
+
+// retryOnConflict retries a mutating call on 409 with backoff.
+func retryOnConflict(ctx context.Context, lbID string, fn func() error) error {
+	backoff := wait.Backoff{Duration: 2 * time.Second, Factor: 1.5, Steps: 6}
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		if err := fn(); err != nil {
+			if isConflict(err) {
+				klog.V(4).Infof("Load balancer %s busy, retrying: %v", lbID, err)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// mutate is retryOnConflict plus a wait for the LB to return to ACTIVE.
+func mutate(ctx context.Context, client *golangsdk.ServiceClient, lbID string, fn func() error) error {
+	if err := retryOnConflict(ctx, lbID, fn); err != nil {
+		return err
+	}
+	return waitForActive(ctx, client, lbID)
+}
+
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var e404 golangsdk.ErrDefault404
+	if errors.As(err, &e404) {
+		return true
+	}
+	var eNF golangsdk.ErrResourceNotFound
+	return errors.As(err, &eNF)
+}
+
+func isConflict(err error) bool {
+	var e409 golangsdk.ErrDefault409
+	return errors.As(err, &e409)
+}
+
+func isBadRequest(err error) bool {
+	var e400 golangsdk.ErrDefault400
+	return errors.As(err, &e400)
+}

--- a/pkg/elb/elb_test.go
+++ b/pkg/elb/elb_test.go
@@ -1,0 +1,593 @@
+package elb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cloudprovider "k8s.io/cloud-provider"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+)
+
+var _ cloudprovider.LoadBalancer = &LoadBalancer{}
+
+func testLoadBalancer(f *fakeELB) *LoadBalancer {
+	opts := config.DefaultLoadBalancerOpts()
+	opts.SubnetID = "subnet-1234"
+	opts.VpcID = "vpc-1234"
+	opts.AvailabilityZones = []string{"eu-de-01"}
+	return &LoadBalancer{
+		opts: opts,
+		newClient: func(_ context.Context) (*golangsdk.ServiceClient, error) {
+			return f.client(), nil
+		},
+		newNetworkClient: func(_ context.Context) (*golangsdk.ServiceClient, error) {
+			return f.networkClient(), nil
+		},
+	}
+}
+
+func testService(ports ...v1.ServicePort) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web",
+			Namespace: "default",
+			UID:       "1234-5678",
+		},
+		Spec: v1.ServiceSpec{
+			Type:  v1.ServiceTypeLoadBalancer,
+			Ports: ports,
+		},
+	}
+}
+
+func testNode(name, ip string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: ip},
+			},
+		},
+	}
+}
+
+func TestGetLoadBalancerName(t *testing.T) {
+	lb := &LoadBalancer{}
+	svc := testService()
+	name := lb.GetLoadBalancerName(context.Background(), "mycluster", svc)
+	want := "kube_service_mycluster_default_web"
+	if name != want {
+		t.Errorf("expected %q, got %q", want, name)
+	}
+}
+
+// TestLoadBalancerLifecycle: create, node update, port removal, deletion.
+func TestLoadBalancerLifecycle(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+
+	svc := testService(
+		v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080},
+		v1.ServicePort{Protocol: v1.ProtocolUDP, Port: 53, NodePort: 30053},
+	)
+	nodes := []*v1.Node{
+		testNode("node-1", "10.0.0.1"),
+		testNode("node-2", "10.0.0.2"),
+	}
+
+	// Before creation nothing exists.
+	if _, exists, err := lb.GetLoadBalancer(ctx, "cluster", svc); err != nil || exists {
+		t.Fatalf("expected no LB before creation, exists=%v err=%v", exists, err)
+	}
+
+	// --- Create ---
+	status, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes)
+	if err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+	if len(status.Ingress) != 1 || status.Ingress[0].IP == "" {
+		t.Fatalf("expected one ingress IP, got %+v", status.Ingress)
+	}
+
+	f.mu.Lock()
+	if len(f.loadBalancers) != 1 {
+		t.Errorf("expected 1 load balancer, got %d", len(f.loadBalancers))
+	}
+	if len(f.listeners) != 2 {
+		t.Errorf("expected 2 listeners, got %d", len(f.listeners))
+	}
+	if len(f.pools) != 2 {
+		t.Errorf("expected 2 pools, got %d", len(f.pools))
+	}
+	if len(f.monitors) != 2 {
+		t.Errorf("expected 2 health monitors, got %d", len(f.monitors))
+	}
+	total := 0
+	for _, pm := range f.members {
+		total += len(pm)
+	}
+	if total != 4 {
+		t.Errorf("expected 4 members (2 nodes x 2 pools), got %d", total)
+	}
+	f.mu.Unlock()
+
+	// Idempotency: a second Ensure must not duplicate anything.
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("second EnsureLoadBalancer failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.listeners) != 2 || len(f.pools) != 2 || len(f.monitors) != 2 {
+		t.Errorf("resources duplicated on repeated ensure: %d listeners, %d pools, %d monitors",
+			len(f.listeners), len(f.pools), len(f.monitors))
+	}
+	f.mu.Unlock()
+
+	// GetLoadBalancer now reports existence.
+	if _, exists, err := lb.GetLoadBalancer(ctx, "cluster", svc); err != nil || !exists {
+		t.Fatalf("expected LB to exist, exists=%v err=%v", exists, err)
+	}
+
+	// --- Node set change ---
+	if err := lb.UpdateLoadBalancer(ctx, "cluster", svc, nodes[:1]); err != nil {
+		t.Fatalf("UpdateLoadBalancer failed: %v", err)
+	}
+	f.mu.Lock()
+	total = 0
+	for _, pm := range f.members {
+		total += len(pm)
+		for _, m := range pm {
+			if m["address"] != "10.0.0.1" {
+				t.Errorf("unexpected member address %v after node removal", m["address"])
+			}
+		}
+	}
+	if total != 2 {
+		t.Errorf("expected 2 members after node removal, got %d", total)
+	}
+	f.mu.Unlock()
+
+	// --- Port removal (stale listener cleanup) ---
+	svcOnePort := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svcOnePort, nodes[:1]); err != nil {
+		t.Fatalf("EnsureLoadBalancer with one port failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.listeners) != 1 || len(f.pools) != 1 || len(f.monitors) != 1 {
+		t.Errorf("expected stale resources removed: %d listeners, %d pools, %d monitors",
+			len(f.listeners), len(f.pools), len(f.monitors))
+	}
+	f.mu.Unlock()
+
+	// --- Delete ---
+	if err := lb.EnsureLoadBalancerDeleted(ctx, "cluster", svcOnePort); err != nil {
+		t.Fatalf("EnsureLoadBalancerDeleted failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.loadBalancers) != 0 || len(f.listeners) != 0 || len(f.pools) != 0 || len(f.monitors) != 0 {
+		t.Errorf("expected everything deleted: %d LBs, %d listeners, %d pools, %d monitors",
+			len(f.loadBalancers), len(f.listeners), len(f.pools), len(f.monitors))
+	}
+	f.mu.Unlock()
+
+	// Deleting again must be a no-op.
+	if err := lb.EnsureLoadBalancerDeleted(ctx, "cluster", svcOnePort); err != nil {
+		t.Fatalf("repeated EnsureLoadBalancerDeleted failed: %v", err)
+	}
+}
+
+// TestSharedLoadBalancer: an LB from the id annotation is reused, not deleted.
+func TestSharedLoadBalancer(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+
+	// Pre-create a "user-managed" load balancer.
+	f.mu.Lock()
+	f.loadBalancers["lb-shared"] = map[string]any{
+		"id":                  "lb-shared",
+		"name":                "user-lb",
+		"provisioning_status": "ACTIVE",
+		"vip_address":         "192.168.0.42",
+		"vip_subnet_cidr_id":  "subnet-1234",
+	}
+	f.mu.Unlock()
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 443, NodePort: 30443})
+	svc.Annotations = map[string]string{AnnotationID: "lb-shared"}
+
+	status, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, []*v1.Node{testNode("node-1", "10.0.0.1")})
+	if err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+	if status.Ingress[0].IP != "192.168.0.42" {
+		t.Errorf("expected shared LB VIP, got %+v", status.Ingress)
+	}
+
+	f.mu.Lock()
+	if len(f.loadBalancers) != 1 {
+		t.Errorf("expected the shared LB to be reused, got %d LBs", len(f.loadBalancers))
+	}
+	f.mu.Unlock()
+
+	if err := lb.EnsureLoadBalancerDeleted(ctx, "cluster", svc); err != nil {
+		t.Fatalf("EnsureLoadBalancerDeleted failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.loadBalancers) != 1 {
+		t.Error("shared load balancer must not be deleted")
+	}
+	if len(f.listeners) != 0 || len(f.pools) != 0 {
+		t.Errorf("expected own listeners/pools removed from shared LB, got %d/%d", len(f.listeners), len(f.pools))
+	}
+	f.mu.Unlock()
+}
+
+// TestEipLifecycle: eip-bandwidth EIP is created, published and released.
+func TestEipLifecycle(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Annotations = map[string]string{AnnotationEipBandwidth: "100"}
+
+	status, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes)
+	if err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+
+	f.mu.Lock()
+	if len(f.eips) != 1 {
+		t.Fatalf("expected 1 EIP created, got %d", len(f.eips))
+	}
+	var eipAddr string
+	for _, e := range f.eips {
+		eipAddr = e["public_ip_address"].(string)
+	}
+	f.mu.Unlock()
+
+	if len(status.Ingress) != 1 || status.Ingress[0].IP != eipAddr {
+		t.Errorf("expected EIP %s in status, got %+v", eipAddr, status.Ingress)
+	}
+
+	if err := lb.EnsureLoadBalancerDeleted(ctx, "cluster", svc); err != nil {
+		t.Fatalf("EnsureLoadBalancerDeleted failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.eips) != 0 {
+		t.Errorf("expected EIP released on deletion, %d left", len(f.eips))
+	}
+	if len(f.loadBalancers) != 0 {
+		t.Errorf("expected load balancer deleted, %d left", len(f.loadBalancers))
+	}
+	f.mu.Unlock()
+}
+
+// TestHTTPHealthCheck: HTTP probe annotations apply and update in place.
+func TestHTTPHealthCheck(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Annotations = map[string]string{
+		AnnotationHealthCheckProtocol:   "HTTP",
+		AnnotationHealthCheckURLPath:    "/healthz",
+		AnnotationHealthCheckHTTPMethod: "HEAD",
+	}
+
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+
+	checkMonitor := func(wantType, wantPath, wantMethod string) {
+		t.Helper()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if len(f.monitors) != 1 {
+			t.Fatalf("expected 1 monitor, got %d", len(f.monitors))
+		}
+		for _, m := range f.monitors {
+			if m["type"] != wantType || m["url_path"] != wantPath || m["http_method"] != wantMethod {
+				t.Errorf("monitor = type:%v path:%v method:%v, want %s %s %s",
+					m["type"], m["url_path"], m["http_method"], wantType, wantPath, wantMethod)
+			}
+		}
+	}
+	checkMonitor("HTTP", "/healthz", "HEAD")
+
+	// Change probe settings: the existing monitor must be updated in place.
+	svc.Annotations[AnnotationHealthCheckURLPath] = "/livez"
+	svc.Annotations[AnnotationHealthCheckHTTPMethod] = "GET"
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer after annotation change failed: %v", err)
+	}
+	checkMonitor("HTTP", "/livez", "GET")
+}
+
+// TestExternalTrafficPolicyLocal: Local probes healthz node port over HTTP;
+// reverting to Cluster recreates a TCP monitor.
+func TestExternalTrafficPolicyLocal(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+	svc.Spec.HealthCheckNodePort = 32001
+
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+
+	checkMonitor := func(wantType string, wantPort any, wantPath string) {
+		t.Helper()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if len(f.monitors) != 1 {
+			t.Fatalf("expected 1 monitor, got %d", len(f.monitors))
+		}
+		for _, m := range f.monitors {
+			gotPath, _ := m["url_path"].(string) // nil (omitted) reads as ""
+			if m["type"] != wantType || gotPath != wantPath {
+				t.Errorf("monitor = type:%v path:%q, want %s %q", m["type"], gotPath, wantType, wantPath)
+			}
+			if fmt.Sprintf("%v", m["monitor_port"]) != fmt.Sprintf("%v", wantPort) {
+				t.Errorf("monitor_port = %v, want %v", m["monitor_port"], wantPort)
+			}
+		}
+	}
+	checkMonitor("HTTP", 32001, "/healthz")
+
+	// Switching back to Cluster must recreate a TCP monitor on member port.
+	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyCluster
+	svc.Spec.HealthCheckNodePort = 0
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer after policy change failed: %v", err)
+	}
+	checkMonitor("TCP", "<nil>", "")
+}
+
+// TestSessionAffinity: SOURCE_IP persistence with timeout, updated in place.
+func TestSessionAffinity(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	timeout := int32(600) // 10 minutes
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+	svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
+		ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &timeout},
+	}
+
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+
+	checkPersistence := func(wantTimeout string) {
+		t.Helper()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		for _, p := range f.pools {
+			sp, ok := p["session_persistence"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected session_persistence on pool, got %v", p["session_persistence"])
+			}
+			if sp["type"] != "SOURCE_IP" || fmt.Sprintf("%v", sp["persistence_timeout"]) != wantTimeout {
+				t.Errorf("persistence = %v, want SOURCE_IP timeout %s", sp, wantTimeout)
+			}
+		}
+	}
+	checkPersistence("10")
+
+	// Timeout change must update the pool in place.
+	newTimeout := int32(1800) // 30 minutes
+	svc.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds = &newTimeout
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer after timeout change failed: %v", err)
+	}
+	checkPersistence("30")
+}
+
+func TestDesiredPersistenceClamping(t *testing.T) {
+	svc := testService()
+	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+
+	if p := desiredPersistence(svc); p == nil || p.Type != "SOURCE_IP" || p.PersistenceTimeout != 0 {
+		t.Errorf("expected SOURCE_IP without explicit timeout, got %+v", p)
+	}
+
+	short := int32(30)
+	svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &short}}
+	if p := desiredPersistence(svc); p.PersistenceTimeout != 1 {
+		t.Errorf("expected 30s to clamp to 1 minute, got %d", p.PersistenceTimeout)
+	}
+
+	long := int32(7200)
+	svc.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds = &long
+	if p := desiredPersistence(svc); p.PersistenceTimeout != 60 {
+		t.Errorf("expected 7200s to clamp to 60 minutes, got %d", p.PersistenceTimeout)
+	}
+
+	svc.Spec.SessionAffinity = v1.ServiceAffinityNone
+	if p := desiredPersistence(svc); p != nil {
+		t.Errorf("expected nil persistence for affinity None, got %+v", p)
+	}
+}
+
+// TestIdleTimeout: idle-timeout annotation lands on the listener.
+func TestIdleTimeout(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Annotations = map[string]string{AnnotationIdleTimeout: "120"}
+
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+	f.mu.Lock()
+	for _, l := range f.listeners {
+		if fmt.Sprintf("%v", l["keepalive_timeout"]) != "120" {
+			t.Errorf("keepalive_timeout = %v, want 120", l["keepalive_timeout"])
+		}
+	}
+	f.mu.Unlock()
+}
+
+// TestEipKeep: eip-keep preserves an auto-created EIP.
+func TestEipKeep(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Annotations = map[string]string{
+		AnnotationEipBandwidth: "50",
+		AnnotationEipKeep:      "true",
+	}
+
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+	if err := lb.EnsureLoadBalancerDeleted(ctx, "cluster", svc); err != nil {
+		t.Fatalf("EnsureLoadBalancerDeleted failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.eips) != 1 {
+		t.Errorf("expected EIP kept with eip-keep=true, got %d EIPs", len(f.eips))
+	}
+	if len(f.loadBalancers) != 0 {
+		t.Errorf("expected load balancer deleted, %d left", len(f.loadBalancers))
+	}
+	f.mu.Unlock()
+}
+
+// TestSourceRanges: loadBalancerSourceRanges maps to a listener ipgroup.
+func TestSourceRanges(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	nodes := []*v1.Node{testNode("node-1", "10.0.0.1")}
+
+	svc := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	svc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8", "192.168.1.0/24"}
+
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+
+	ipCount := func() int {
+		t.Helper()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if len(f.ipGroups) != 1 {
+			t.Fatalf("expected 1 ipgroup, got %d", len(f.ipGroups))
+		}
+		for _, g := range f.ipGroups {
+			return len(g["ip_list"].([]any))
+		}
+		return 0
+	}
+	if n := ipCount(); n != 2 {
+		t.Errorf("expected 2 CIDRs in ipgroup, got %d", n)
+	}
+
+	// Listener must have the whitelist attached and enabled.
+	f.mu.Lock()
+	for _, l := range f.listeners {
+		ig, ok := l["ipgroup"].(map[string]any)
+		if !ok || ig["enable_ipgroup"] != true || ig["type"] != "white" {
+			t.Errorf("expected enabled white ipgroup on listener, got %v", l["ipgroup"])
+		}
+	}
+	f.mu.Unlock()
+
+	// Range change updates the group in place.
+	svc.Spec.LoadBalancerSourceRanges = []string{"172.16.0.0/12"}
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer after range change failed: %v", err)
+	}
+	if n := ipCount(); n != 1 {
+		t.Errorf("expected 1 CIDR after update, got %d", n)
+	}
+
+	// Clearing the ranges disables the whitelist.
+	svc.Spec.LoadBalancerSourceRanges = nil
+	if _, err := lb.EnsureLoadBalancer(ctx, "cluster", svc, nodes); err != nil {
+		t.Fatalf("EnsureLoadBalancer after clearing ranges failed: %v", err)
+	}
+	f.mu.Lock()
+	for _, l := range f.listeners {
+		ig, ok := l["ipgroup"].(map[string]any)
+		if !ok || ig["enable_ipgroup"] != false {
+			t.Errorf("expected disabled ipgroup after clearing ranges, got %v", l["ipgroup"])
+		}
+	}
+	f.mu.Unlock()
+
+	// Deleting the service removes the group.
+	if err := lb.EnsureLoadBalancerDeleted(ctx, "cluster", svc); err != nil {
+		t.Fatalf("EnsureLoadBalancerDeleted failed: %v", err)
+	}
+	f.mu.Lock()
+	if len(f.ipGroups) != 0 {
+		t.Errorf("expected ipgroup deleted with the service, %d left", len(f.ipGroups))
+	}
+	f.mu.Unlock()
+}
+
+func TestEnsureLoadBalancerValidation(t *testing.T) {
+	f := newFakeELB()
+	defer f.close()
+	lb := testLoadBalancer(f)
+	ctx := context.Background()
+	node := testNode("node-1", "10.0.0.1")
+
+	// No ports.
+	if _, err := lb.EnsureLoadBalancer(ctx, "c", testService(), []*v1.Node{node}); err == nil {
+		t.Error("expected error for service without ports")
+	}
+
+	// Unsupported protocol.
+	sctp := testService(v1.ServicePort{Protocol: v1.ProtocolSCTP, Port: 80, NodePort: 30080})
+	if _, err := lb.EnsureLoadBalancer(ctx, "c", sctp, []*v1.Node{node}); err == nil {
+		t.Error("expected error for SCTP port")
+	}
+
+	// No nodes.
+	tcp := testService(v1.ServicePort{Protocol: v1.ProtocolTCP, Port: 80, NodePort: 30080})
+	if _, err := lb.EnsureLoadBalancer(ctx, "c", tcp, nil); err == nil {
+		t.Error("expected error for empty node list")
+	}
+
+	// Missing subnet configuration.
+	lbNoSubnet := testLoadBalancer(f)
+	lbNoSubnet.opts.SubnetID = ""
+	if _, err := lbNoSubnet.EnsureLoadBalancer(ctx, "c", tcp, []*v1.Node{node}); err == nil {
+		t.Error("expected error when subnet-id is not configured")
+	}
+}

--- a/pkg/elb/fake_elb_test.go
+++ b/pkg/elb/fake_elb_test.go
@@ -1,0 +1,413 @@
+package elb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// fakeELB is an in-memory ELBv3 API subset backing the lifecycle tests.
+type fakeELB struct {
+	mu sync.Mutex
+
+	server *httptest.Server
+
+	nextID int
+
+	loadBalancers map[string]map[string]any // id -> object
+	listeners     map[string]map[string]any
+	pools         map[string]map[string]any
+	monitors      map[string]map[string]any
+	// members: poolID -> memberID -> object
+	members map[string]map[string]map[string]any
+	// eips: EIP id -> object (network v1 publicips API)
+	eips map[string]map[string]any
+	// ipGroups: group id -> object
+	ipGroups map[string]map[string]any
+}
+
+func newFakeELB() *fakeELB {
+	f := &fakeELB{
+		loadBalancers: map[string]map[string]any{},
+		listeners:     map[string]map[string]any{},
+		pools:         map[string]map[string]any{},
+		monitors:      map[string]map[string]any{},
+		members:       map[string]map[string]map[string]any{},
+		eips:          map[string]map[string]any{},
+		ipGroups:      map[string]map[string]any{},
+	}
+	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
+	return f
+}
+
+func (f *fakeELB) close() { f.server.Close() }
+
+func (f *fakeELB) client() *golangsdk.ServiceClient {
+	return &golangsdk.ServiceClient{
+		ProviderClient: &golangsdk.ProviderClient{},
+		Endpoint:       f.server.URL + "/",
+		ResourceBase:   f.server.URL + "/elb/",
+	}
+}
+
+// networkClient mimics a NewNetworkV1 client (URLs: <base>/<project>/publicips).
+func (f *fakeELB) networkClient() *golangsdk.ServiceClient {
+	return &golangsdk.ServiceClient{
+		ProviderClient: &golangsdk.ProviderClient{ProjectID: "test-project"},
+		Endpoint:       f.server.URL + "/net/",
+		ResourceBase:   f.server.URL + "/net/v1/",
+	}
+}
+
+func (f *fakeELB) genID(prefix string) string {
+	f.nextID++
+	return fmt.Sprintf("%s-%04d", prefix, f.nextID)
+}
+
+func (f *fakeELB) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Network v1 API (EIPs): /net/v1/<project>/publicips[/<id>]
+	if strings.HasPrefix(r.URL.Path, "/net/") {
+		parts := strings.Split(strings.Trim(strings.TrimPrefix(r.URL.Path, "/net/v1/"), "/"), "/")
+		if len(parts) >= 2 && parts[1] == "publicips" {
+			f.handleEips(w, r, parts[2:])
+			return
+		}
+		http.Error(w, `{"error": "unknown network path"}`, http.StatusNotFound)
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/elb/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+
+	switch {
+	case parts[0] == "loadbalancers":
+		f.handleLoadBalancers(w, r, parts[1:])
+	case parts[0] == "listeners":
+		f.handleListeners(w, r, parts[1:])
+	case parts[0] == "pools" && len(parts) >= 3 && parts[2] == "members":
+		f.handleMembers(w, r, parts)
+	case parts[0] == "pools":
+		f.handlePools(w, r, parts[1:])
+	case parts[0] == "healthmonitors":
+		f.handleMonitors(w, r, parts[1:])
+	case parts[0] == "ipgroups":
+		f.handleIPGroups(w, r, parts[1:])
+	default:
+		http.Error(w, `{"error": "unknown path `+r.URL.Path+`"}`, http.StatusNotFound)
+	}
+}
+
+func (f *fakeELB) handleLoadBalancers(w http.ResponseWriter, r *http.Request, rest []string) {
+	switch {
+	case len(rest) == 0 && r.Method == http.MethodPost:
+		body := readBody(r, "loadbalancer")
+		id := f.genID("lb")
+		body["id"] = id
+		body["provisioning_status"] = "ACTIVE"
+		body["operating_status"] = "ONLINE"
+		if body["vip_address"] == nil || body["vip_address"] == "" {
+			body["vip_address"] = "192.168.0.100"
+		}
+		// A nested publicip block creates and binds a new EIP.
+		if _, ok := body["publicip"]; ok {
+			eipID := f.genID("eip")
+			addr := fmt.Sprintf("80.158.0.%d", f.nextID)
+			f.eips[eipID] = map[string]any{"id": eipID, "public_ip_address": addr, "port_id": ""}
+			body["publicips"] = []any{map[string]any{"publicip_id": eipID, "publicip_address": addr, "ip_version": 4}}
+			delete(body, "publicip")
+		}
+		f.loadBalancers[id] = body
+		writeJSON(w, http.StatusCreated, map[string]any{"loadbalancer": body})
+	case len(rest) == 0 && r.Method == http.MethodGet:
+		name := r.URL.Query().Get("name")
+		var items []map[string]any
+		for _, lb := range f.loadBalancers {
+			if name == "" || lb["name"] == name {
+				items = append(items, lb)
+			}
+		}
+		writeList(w, "loadbalancers", items)
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		lb, ok := f.loadBalancers[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"loadbalancer": lb})
+	case len(rest) == 1 && r.Method == http.MethodDelete:
+		if _, ok := f.loadBalancers[rest[0]]; !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		delete(f.loadBalancers, rest[0])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fakeELB) handleListeners(w http.ResponseWriter, r *http.Request, rest []string) {
+	switch {
+	case len(rest) == 0 && r.Method == http.MethodPost:
+		body := readBody(r, "listener")
+		id := f.genID("listener")
+		body["id"] = id
+		body["default_pool_id"] = ""
+		f.listeners[id] = body
+		writeJSON(w, http.StatusCreated, map[string]any{"listener": body})
+	case len(rest) == 0 && r.Method == http.MethodGet:
+		lbID := r.URL.Query().Get("loadbalancer_id")
+		var items []map[string]any
+		for _, l := range f.listeners {
+			if lbID == "" || l["loadbalancer_id"] == lbID {
+				items = append(items, l)
+			}
+		}
+		writeList(w, "listeners", items)
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		l, ok := f.listeners[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"listener": l})
+	case len(rest) == 1 && r.Method == http.MethodPut:
+		l, ok := f.listeners[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		for k, v := range readBody(r, "listener") {
+			l[k] = v
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"listener": l})
+	case len(rest) == 1 && r.Method == http.MethodDelete:
+		if _, ok := f.listeners[rest[0]]; !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		delete(f.listeners, rest[0])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fakeELB) handlePools(w http.ResponseWriter, r *http.Request, rest []string) {
+	switch {
+	case len(rest) == 0 && r.Method == http.MethodPost:
+		body := readBody(r, "pool")
+		id := f.genID("pool")
+		body["id"] = id
+		body["healthmonitor_id"] = ""
+		if listenerID, _ := body["listener_id"].(string); listenerID != "" {
+			if l, ok := f.listeners[listenerID]; ok {
+				l["default_pool_id"] = id
+			}
+		}
+		f.pools[id] = body
+		f.members[id] = map[string]map[string]any{}
+		writeJSON(w, http.StatusCreated, map[string]any{"pool": body})
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		p, ok := f.pools[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"pool": p})
+	case len(rest) == 1 && r.Method == http.MethodPut:
+		p, ok := f.pools[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		for k, v := range readBody(r, "pool") {
+			p[k] = v
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"pool": p})
+	case len(rest) == 1 && r.Method == http.MethodDelete:
+		if _, ok := f.pools[rest[0]]; !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		delete(f.pools, rest[0])
+		delete(f.members, rest[0])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fakeELB) handleMembers(w http.ResponseWriter, r *http.Request, parts []string) {
+	// parts: ["pools", poolID, "members"] or ["pools", poolID, "members", memberID]
+	poolID := parts[1]
+	pool, ok := f.members[poolID]
+	if !ok {
+		http.Error(w, `{"error": "pool not found"}`, http.StatusNotFound)
+		return
+	}
+	switch {
+	case len(parts) == 3 && r.Method == http.MethodPost:
+		body := readBody(r, "member")
+		id := f.genID("member")
+		body["id"] = id
+		body["pool_id"] = poolID
+		pool[id] = body
+		writeJSON(w, http.StatusCreated, map[string]any{"member": body})
+	case len(parts) == 3 && r.Method == http.MethodGet:
+		var items []map[string]any
+		for _, m := range pool {
+			items = append(items, m)
+		}
+		writeList(w, "members", items)
+	case len(parts) == 4 && r.Method == http.MethodDelete:
+		if _, ok := pool[parts[3]]; !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		delete(pool, parts[3])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fakeELB) handleMonitors(w http.ResponseWriter, r *http.Request, rest []string) {
+	switch {
+	case len(rest) == 0 && r.Method == http.MethodPost:
+		body := readBody(r, "healthmonitor")
+		id := f.genID("monitor")
+		body["id"] = id
+		if poolID, _ := body["pool_id"].(string); poolID != "" {
+			if p, ok := f.pools[poolID]; ok {
+				p["healthmonitor_id"] = id
+			}
+		}
+		f.monitors[id] = body
+		writeJSON(w, http.StatusCreated, map[string]any{"healthmonitor": body})
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		m, ok := f.monitors[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"healthmonitor": m})
+	case len(rest) == 1 && r.Method == http.MethodPut:
+		m, ok := f.monitors[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		for k, v := range readBody(r, "healthmonitor") {
+			m[k] = v
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"healthmonitor": m})
+	case len(rest) == 1 && r.Method == http.MethodDelete:
+		m, ok := f.monitors[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		if poolID, _ := m["pool_id"].(string); poolID != "" {
+			if p, ok := f.pools[poolID]; ok {
+				p["healthmonitor_id"] = ""
+			}
+		}
+		delete(f.monitors, rest[0])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fakeELB) handleEips(w http.ResponseWriter, r *http.Request, rest []string) {
+	switch {
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		eip, ok := f.eips[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"publicip": eip})
+	case len(rest) == 1 && r.Method == http.MethodDelete:
+		if _, ok := f.eips[rest[0]]; !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		delete(f.eips, rest[0])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (f *fakeELB) handleIPGroups(w http.ResponseWriter, r *http.Request, rest []string) {
+	switch {
+	case len(rest) == 0 && r.Method == http.MethodPost:
+		body := readBody(r, "ipgroup")
+		id := f.genID("ipgroup")
+		body["id"] = id
+		f.ipGroups[id] = body
+		writeJSON(w, http.StatusCreated, map[string]any{"ipgroup": body})
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		g, ok := f.ipGroups[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ipgroup": g})
+	case len(rest) == 1 && r.Method == http.MethodPut:
+		g, ok := f.ipGroups[rest[0]]
+		if !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		for k, v := range readBody(r, "ipgroup") {
+			g[k] = v
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ipgroup": g})
+	case len(rest) == 1 && r.Method == http.MethodDelete:
+		if _, ok := f.ipGroups[rest[0]]; !ok {
+			http.Error(w, `{"error": "not found"}`, http.StatusNotFound)
+			return
+		}
+		delete(f.ipGroups, rest[0])
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, `{"error": "unsupported"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func readBody(r *http.Request, envelope string) map[string]any {
+	var wrapper map[string]map[string]any
+	_ = json.NewDecoder(r.Body).Decode(&wrapper)
+	body := wrapper[envelope]
+	if body == nil {
+		body = map[string]any{}
+	}
+	return body
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeList(w http.ResponseWriter, key string, items []map[string]any) {
+	if items == nil {
+		items = []map[string]any{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		key:         items,
+		"page_info": map[string]any{"next_marker": "", "current_count": len(items)},
+	})
+}

--- a/pkg/elb/ipgroups.go
+++ b/pkg/elb/ipgroups.go
@@ -1,0 +1,169 @@
+package elb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/ipgroups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/listeners"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// reconcileIPGroup enforces spec.loadBalancerSourceRanges on a listener via
+// an ELB IP address group (whitelist).
+func (lb *LoadBalancer) reconcileIPGroup(ctx context.Context, client *golangsdk.ServiceClient, lbID string, listener *listeners.Listener, name string, service *v1.Service, port v1.ServicePort) error {
+	ranges := normalizeRanges(service.Spec.LoadBalancerSourceRanges)
+	groupName := cutString(fmt.Sprintf("%s_%s_%d", name, port.Protocol, port.Port), maxResourceNameLength)
+
+	attachedID := listener.IpGroup.IpGroupID
+
+	if len(ranges) == 0 {
+		// No restriction wanted: disable our whitelist if one is attached.
+		// The SDK cannot fully detach a group, so it is kept (disabled)
+		// and removed together with the listener.
+		if attachedID == "" {
+			return nil
+		}
+		group, err := ipgroups.Get(client, attachedID)
+		if err != nil {
+			if isNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to get ipgroup %s: %w", attachedID, err)
+		}
+		if group.Name != groupName || listener.IpGroup.Enable == nil || !*listener.IpGroup.Enable {
+			return nil // foreign group or already disabled
+		}
+		disabled := false
+		err = mutate(ctx, client, lbID, func() error {
+			_, err := listeners.Update(client, listener.ID, listeners.UpdateOpts{
+				IpGroup: &listeners.IpGroupUpdate{IpGroupId: attachedID, Enable: &disabled},
+			}).Extract()
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("failed to disable ipgroup on listener %s: %w", listener.ID, err)
+		}
+		klog.V(2).Infof("Disabled source-range whitelist on listener %s", listener.ID)
+		return nil
+	}
+
+	if attachedID != "" {
+		group, err := ipgroups.Get(client, attachedID)
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("failed to get ipgroup %s: %w", attachedID, err)
+		}
+		if err == nil {
+			if group.Name != groupName {
+				return fmt.Errorf("listener %s already has a foreign ipgroup %s; remove it or drop loadBalancerSourceRanges", listener.ID, group.ID)
+			}
+			if !ipListEqual(group.IpList, ranges) {
+				err := retryOnConflict(ctx, lbID, func() error {
+					return ipgroups.Update(client, group.ID, ipgroups.UpdateOpts{IpList: ipList(ranges)})
+				})
+				if err != nil {
+					return fmt.Errorf("failed to update ipgroup %s: %w", group.ID, err)
+				}
+				klog.V(2).Infof("Updated source ranges of ipgroup %s", group.ID)
+			}
+			// Re-enable in case the whitelist was disabled earlier.
+			if listener.IpGroup.Enable == nil || !*listener.IpGroup.Enable {
+				return lb.attachIPGroup(ctx, client, lbID, listener.ID, group.ID)
+			}
+			return nil
+		}
+		// Attached group vanished: fall through and create a new one.
+	}
+
+	group, err := ipgroups.Create(client, ipgroups.CreateOpts{
+		Name:        groupName,
+		Description: fmt.Sprintf("Kubernetes service %s/%s", service.Namespace, service.Name),
+		IpList:      ipList(ranges),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create ipgroup for listener %s: %w", listener.ID, err)
+	}
+	klog.V(2).Infof("Created ipgroup %s (%s)", group.Name, group.ID)
+	return lb.attachIPGroup(ctx, client, lbID, listener.ID, group.ID)
+}
+
+func (lb *LoadBalancer) attachIPGroup(ctx context.Context, client *golangsdk.ServiceClient, lbID, listenerID, groupID string) error {
+	enabled := true
+	err := mutate(ctx, client, lbID, func() error {
+		_, err := listeners.Update(client, listenerID, listeners.UpdateOpts{
+			IpGroup: &listeners.IpGroupUpdate{IpGroupId: groupID, Enable: &enabled, Type: "white"},
+		}).Extract()
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to attach ipgroup %s to listener %s: %w", groupID, listenerID, err)
+	}
+	klog.V(2).Infof("Attached ipgroup %s to listener %s", groupID, listenerID)
+	return nil
+}
+
+// deleteIPGroup removes the listener's IP group if this Service owns it.
+// Call after the listener is deleted, when the group is no longer bound.
+func (lb *LoadBalancer) deleteIPGroup(ctx context.Context, client *golangsdk.ServiceClient, lbID, groupID, name string) error {
+	if groupID == "" {
+		return nil
+	}
+	group, err := ipgroups.Get(client, groupID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get ipgroup %s: %w", groupID, err)
+	}
+	if !strings.HasPrefix(group.Name, name+"_") {
+		return nil // not ours
+	}
+	err = retryOnConflict(ctx, lbID, func() error {
+		if err := ipgroups.Delete(client, groupID); err != nil && !isNotFound(err) {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete ipgroup %s: %w", groupID, err)
+	}
+	klog.V(2).Infof("Deleted ipgroup %s", groupID)
+	return nil
+}
+
+func normalizeRanges(ranges []string) []string {
+	var out []string
+	for _, r := range ranges {
+		if r = strings.TrimSpace(r); r != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func ipList(ranges []string) *[]ipgroups.IpGroupOption {
+	list := make([]ipgroups.IpGroupOption, 0, len(ranges))
+	for _, r := range ranges {
+		list = append(list, ipgroups.IpGroupOption{Ip: r})
+	}
+	return &list
+}
+
+func ipListEqual(current []ipgroups.IpInfo, ranges []string) bool {
+	if len(current) != len(ranges) {
+		return false
+	}
+	have := make(map[string]bool, len(current))
+	for _, ip := range current {
+		have[ip.Ip] = true
+	}
+	for _, r := range ranges {
+		if !have[r] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/identity/aksk.go
+++ b/pkg/identity/aksk.go
@@ -77,21 +77,12 @@ func (p *akskProvider) GetProvider(_ context.Context) (*golangsdk.ProviderClient
 	return p.client, nil
 }
 
-func (p *akskProvider) GetServiceClient(ctx context.Context, _ string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+func (p *akskProvider) GetServiceClient(ctx context.Context, service string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	provider, err := p.GetProvider(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	endpoint, err := provider.EndpointLocator(opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to locate endpoint: %w", err)
-	}
-
-	return &golangsdk.ServiceClient{
-		ProviderClient: provider,
-		Endpoint:       endpoint,
-	}, nil
+	return newServiceClient(provider, service, opts)
 }
 
 func (p *akskProvider) AuthMethod() string {

--- a/pkg/identity/aksk_test.go
+++ b/pkg/identity/aksk_test.go
@@ -98,8 +98,8 @@ func TestAKSKProvider_Authenticate(t *testing.T) {
 
 	opts := config.AuthOpts{
 		AuthURL:    server.URL + "/v3",
-		AccessKey:  "AKIAIOSFODNN7EXAMPLE",
-		SecretKey:  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		AccessKey:  "test-access-key",
+		SecretKey:  "test-secret-key",
 		ProjectID:  "test-project-id",
 		DomainName: "test-domain",
 		Region:     "eu-de",
@@ -115,8 +115,8 @@ func TestAKSKProvider_Authenticate(t *testing.T) {
 		t.Fatalf("unexpected error authenticating: %v", err)
 	}
 
-	if client.AKSKAuthOptions.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("AccessKey = %q, want %q", client.AKSKAuthOptions.AccessKey, "AKIAIOSFODNN7EXAMPLE")
+	if client.AKSKAuthOptions.AccessKey != "test-access-key" {
+		t.Errorf("AccessKey = %q, want %q", client.AKSKAuthOptions.AccessKey, "test-access-key")
 	}
 
 	// Verify SDK-HMAC-SHA256 headers were used in requests
@@ -130,7 +130,7 @@ func TestAKSKProvider_Authenticate(t *testing.T) {
 		}
 	}
 	if !foundHMAC {
-		t.Errorf("expected SDK-HMAC-SHA256 Authorization header in requests, got: %v", authHeaders)
+		t.Errorf("expected SDK-HMAC-SHA256 Authorization header in requests, got %d headers, none matching", len(authHeaders))
 	}
 }
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -10,7 +10,9 @@ import (
 type IdentityProvider interface {
 	// GetProvider returns an authenticated ProviderClient.
 	GetProvider(ctx context.Context) (*golangsdk.ProviderClient, error)
-	// GetServiceClient returns a ServiceClient for the given service type.
+	// GetServiceClient returns a ServiceClient for the given service type
+	// (one of the Service* constants, e.g. ServiceELBv3). The client is
+	// built via the SDK constructors so per-service endpoint fixups apply.
 	GetServiceClient(ctx context.Context, service string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error)
 	// AuthMethod returns the authentication method name (e.g., "password", "aksk").
 	AuthMethod() string

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -9,8 +9,8 @@ import (
 func TestNewIdentityProvider_AKSK(t *testing.T) {
 	opts := config.AuthOpts{
 		AuthURL:   "https://iam.eu-de.otc.t-systems.com/v3",
-		AccessKey: "AKIAIOSFODNN7EXAMPLE",
-		SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		AccessKey: "test-access-key",
+		SecretKey: "test-secret-key",
 		Region:    "eu-de",
 	}
 

--- a/pkg/identity/password.go
+++ b/pkg/identity/password.go
@@ -79,21 +79,12 @@ func (p *passwordProvider) GetProvider(_ context.Context) (*golangsdk.ProviderCl
 	return p.client, nil
 }
 
-func (p *passwordProvider) GetServiceClient(ctx context.Context, _ string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+func (p *passwordProvider) GetServiceClient(ctx context.Context, service string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	provider, err := p.GetProvider(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	endpoint, err := provider.EndpointLocator(opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to locate endpoint: %w", err)
-	}
-
-	return &golangsdk.ServiceClient{
-		ProviderClient: provider,
-		Endpoint:       endpoint,
-	}, nil
+	return newServiceClient(provider, service, opts)
 }
 
 func (p *passwordProvider) AuthMethod() string {

--- a/pkg/identity/service_client.go
+++ b/pkg/identity/service_client.go
@@ -1,0 +1,27 @@
+package identity
+
+import (
+	"fmt"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+)
+
+// Service types accepted by IdentityProvider.GetServiceClient.
+const (
+	ServiceELBv3     = "elbv3"
+	ServiceNetworkV1 = "network"
+)
+
+// newServiceClient delegates to the SDK constructors, which apply the
+// per-service endpoint fixups a raw endpoint lookup would miss.
+func newServiceClient(provider *golangsdk.ProviderClient, service string, opts golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	switch service {
+	case ServiceELBv3:
+		return openstack.NewELBV3(provider, opts)
+	case ServiceNetworkV1:
+		return openstack.NewNetworkV1(provider, opts)
+	default:
+		return nil, fmt.Errorf("unsupported service type %q", service)
+	}
+}

--- a/pkg/identity/service_client_test.go
+++ b/pkg/identity/service_client_test.go
@@ -1,0 +1,38 @@
+package identity
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+func fakeProvider(endpoint string) *golangsdk.ProviderClient {
+	return &golangsdk.ProviderClient{
+		EndpointLocator: func(golangsdk.EndpointOpts) (string, error) {
+			return endpoint, nil
+		},
+	}
+}
+
+func TestNewServiceClient_ELBv3(t *testing.T) {
+	endpoint := "https://elb.eu-de.otc.t-systems.com/v3/project-id/"
+	sc, err := newServiceClient(fakeProvider(endpoint), ServiceELBv3, golangsdk.EndpointOpts{Region: "eu-de"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc.Endpoint != endpoint {
+		t.Errorf("Endpoint = %q, want %q", sc.Endpoint, endpoint)
+	}
+	// The SDK constructor must apply the ELBv3 fixup; without it all
+	// resource URLs would miss the "elb/" path segment.
+	if want := endpoint + "elb/"; sc.ResourceBase != want {
+		t.Errorf("ResourceBase = %q, want %q", sc.ResourceBase, want)
+	}
+}
+
+func TestNewServiceClient_UnknownService(t *testing.T) {
+	_, err := newServiceClient(fakeProvider("https://example.com/"), "no-such-service", golangsdk.EndpointOpts{})
+	if err == nil {
+		t.Fatal("expected error for unknown service type")
+	}
+}

--- a/pkg/opentelekomcloud/opentelekomcloud.go
+++ b/pkg/opentelekomcloud/opentelekomcloud.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/elb"
 	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/identity"
 )
 
@@ -24,11 +25,14 @@ func init() {
 	})
 }
 
+// CloudProvider implements cloudprovider.Interface for Open Telekom Cloud.
 type CloudProvider struct {
-	cloudprovider.Interface
 	identity identity.IdentityProvider
 	config   *config.CloudConfig
+	lb       cloudprovider.LoadBalancer
 }
+
+var _ cloudprovider.Interface = &CloudProvider{}
 
 func NewOTC(cfg io.Reader) (*CloudProvider, error) {
 	cc, err := config.ReadConfig(cfg)
@@ -43,15 +47,49 @@ func NewOTC(cfg io.Reader) (*CloudProvider, error) {
 
 	klog.Infof("OTC cloud provider initialized with auth method: %s", idProvider.AuthMethod())
 
-	return &CloudProvider{
+	cp := &CloudProvider{
 		identity: idProvider,
 		config:   cc,
-	}, nil
+	}
+	// The getter is evaluated per call, so the load balancer picks up the
+	// token-cache wrapper installed by Initialize.
+	cp.lb = elb.NewLoadBalancer(func() identity.IdentityProvider { return cp.identity }, cc.LoadBalancer)
+	return cp, nil
 }
 
 func (cp *CloudProvider) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
 	cp.identity = identity.WithTokenCache(cp.identity, nil, stop)
 	klog.Info("OTC cloud provider token cache initialized")
+}
+
+// LoadBalancer returns the load balancer implementation backed by OTC ELBv3.
+func (cp *CloudProvider) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return cp.lb, true
+}
+
+// Instances is not implemented yet.
+func (cp *CloudProvider) Instances() (cloudprovider.Instances, bool) {
+	return nil, false
+}
+
+// InstancesV2 is not implemented yet.
+func (cp *CloudProvider) InstancesV2() (cloudprovider.InstancesV2, bool) {
+	return nil, false
+}
+
+// Zones is not implemented yet.
+func (cp *CloudProvider) Zones() (cloudprovider.Zones, bool) {
+	return nil, false
+}
+
+// Clusters is not supported.
+func (cp *CloudProvider) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+// Routes is not supported.
+func (cp *CloudProvider) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
 }
 
 func (cp *CloudProvider) ProviderName() string {

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,48 @@
+# Functional (e2e) tests
+
+These tests run against a **live Kubernetes cluster on Open Telekom Cloud**
+with this cloud controller manager deployed. They create a namespace, an nginx
+deployment and `LoadBalancer` Services, wait for the load balancer to be
+provisioned, optionally verify HTTP reachability, and clean everything up.
+
+They are excluded from normal builds by the `e2e` build tag and never run as
+part of `make test` or CI unit tests.
+
+## Prerequisites
+
+1. A Kubernetes cluster running on OTC nodes.
+2. The cloud controller manager deployed and healthy, see
+   [`manifests/`](../../manifests): the `cloud-config` secret must contain a
+   valid `[LoadBalancer]` section (`subnet-id`, `availability-zone`, ...) so
+   load balancers can be created without per-Service annotations.
+3. `KUBECONFIG` pointing at the cluster (or `~/.kube/config`).
+4. Network access from the test runner to the cluster API. The HTTP
+   reachability check additionally needs access to the load balancer VIP –
+   run the tests from inside the VPC, or set `E2E_EIP_BANDWIDTH` to test via
+   a public EIP.
+
+## Running
+
+```sh
+make test-e2e
+# or directly:
+go test -tags e2e ./test/e2e/ -v -timeout 40m
+```
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `E2E_TIMEOUT` | Per-wait timeout as Go duration (default `10m`). |
+| `E2E_SUBNET_ID` | Adds the subnet-id annotation to test Services (overrides cloud-config default). |
+| `E2E_AVAILABILITY_ZONES` | Adds the availability-zones annotation (comma-separated). |
+| `E2E_EIP_BANDWIDTH` | Requests a public EIP with the given bandwidth (Mbit/s) and enables the HTTP reachability check. The EIP is released with the Service. |
+| `E2E_CHECK_HTTP` | `true` forces the HTTP check even without an EIP (requires in-VPC runner). |
+
+## Scenarios
+
+- `TestLoadBalancerService` – full lifecycle: provision, (optional) HTTP
+  check through the load balancer, add a second port, delete and wait for
+  cloud resource cleanup.
+- `TestLoadBalancerSessionAffinity` – provisioning with `ClientIP` session
+  affinity and timeout mapping.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,270 @@
+//go:build e2e
+
+// Package e2e runs against a live cluster with the CCM deployed; see README.
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/elb"
+)
+
+const (
+	appLabel     = "e2e-nginx"
+	pollInterval = 5 * time.Second
+)
+
+func testTimeout() time.Duration {
+	if v := os.Getenv("E2E_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return 10 * time.Minute
+}
+
+func newKubeClient(t *testing.T) kubernetes.Interface {
+	t.Helper()
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, nil).ClientConfig()
+	if err != nil {
+		t.Fatalf("cannot load kubeconfig (set KUBECONFIG or provide ~/.kube/config): %v", err)
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("cannot create Kubernetes client: %v", err)
+	}
+	return client
+}
+
+func setupNamespace(ctx context.Context, t *testing.T, client kubernetes.Interface) string {
+	t.Helper()
+	name := fmt.Sprintf("ccm-e2e-%05d", rand.Intn(100000))
+	_, err := client.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create namespace %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = client.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{})
+	})
+	return name
+}
+
+func deployNginx(ctx context.Context, t *testing.T, client kubernetes.Interface, namespace string) {
+	t.Helper()
+	replicas := int32(2)
+	_, err := client.AppsV1().Deployments(namespace).Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: appLabel},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appLabel}},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:  "nginx",
+						Image: "nginx:1.27",
+						Ports: []v1.ContainerPort{{ContainerPort: 80}},
+					}},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create deployment: %v", err)
+	}
+}
+
+// serviceAnnotations builds LB annotations from E2E_* env overrides.
+func serviceAnnotations() map[string]string {
+	ann := map[string]string{}
+	if v := os.Getenv("E2E_SUBNET_ID"); v != "" {
+		ann[elb.AnnotationSubnetID] = v
+	}
+	if v := os.Getenv("E2E_AVAILABILITY_ZONES"); v != "" {
+		ann[elb.AnnotationAvailabilityZones] = v
+	}
+	if v := os.Getenv("E2E_EIP_BANDWIDTH"); v != "" {
+		ann[elb.AnnotationEipBandwidth] = v
+	}
+	return ann
+}
+
+func createLBService(ctx context.Context, t *testing.T, client kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	_, err := client.CoreV1().Services(namespace).Create(ctx, &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: serviceAnnotations(),
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{"app": appLabel},
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   v1.ProtocolTCP,
+				Port:       80,
+				TargetPort: intstr.FromInt32(80),
+			}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+}
+
+func waitForIngress(ctx context.Context, t *testing.T, client kubernetes.Interface, namespace, name string) string {
+	t.Helper()
+	var ingress string
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, testTimeout(), true, func(ctx context.Context) (bool, error) {
+		svc, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(svc.Status.LoadBalancer.Ingress) > 0 && svc.Status.LoadBalancer.Ingress[0].IP != "" {
+			ingress = svc.Status.LoadBalancer.Ingress[0].IP
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("service %s/%s did not get an ingress IP: %v", namespace, name, err)
+	}
+	return ingress
+}
+
+func checkHTTP(t *testing.T, url string) {
+	t.Helper()
+	httpClient := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, // #nosec G402 -- test traffic to a fresh LB
+	}
+	deadline := time.Now().Add(testTimeout())
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := httpClient.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			lastErr = fmt.Errorf("unexpected status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("HTTP check of %s failed: %v", url, lastErr)
+}
+
+func deleteServiceAndWait(ctx context.Context, t *testing.T, client kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	if err := client.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("failed to delete service: %v", err)
+	}
+	// The Service stays until the cloud LB is gone and the finalizer dropped.
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, testTimeout(), true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("service %s/%s was not cleaned up: %v", namespace, name, err)
+	}
+}
+
+// TestLoadBalancerService: provision, optional HTTP check, update, delete.
+func TestLoadBalancerService(t *testing.T) {
+	ctx := context.Background()
+	client := newKubeClient(t)
+	namespace := setupNamespace(ctx, t, client)
+	deployNginx(ctx, t, client, namespace)
+
+	const svcName = "e2e-lb"
+	createLBService(ctx, t, client, namespace, svcName)
+
+	ingress := waitForIngress(ctx, t, client, namespace, svcName)
+	t.Logf("service got ingress IP %s", ingress)
+
+	// The VIP is VPC-private; check HTTP only when enabled or an EIP exists.
+	if os.Getenv("E2E_CHECK_HTTP") == "true" || os.Getenv("E2E_EIP_BANDWIDTH") != "" {
+		checkHTTP(t, "http://"+ingress)
+		t.Log("HTTP check passed")
+	}
+
+	// Reconfigure: add a second port and verify the service stays healthy.
+	svc, err := client.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get service: %v", err)
+	}
+	svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
+		Name:       "http-alt",
+		Protocol:   v1.ProtocolTCP,
+		Port:       8080,
+		TargetPort: intstr.FromInt32(80),
+	})
+	if _, err := client.CoreV1().Services(namespace).Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to update service: %v", err)
+	}
+	waitForIngress(ctx, t, client, namespace, svcName)
+	t.Log("service updated with second port")
+
+	deleteServiceAndWait(ctx, t, client, namespace, svcName)
+	t.Log("service and load balancer deleted")
+}
+
+// TestLoadBalancerSessionAffinity: ClientIP affinity LB provisions fine.
+func TestLoadBalancerSessionAffinity(t *testing.T) {
+	ctx := context.Background()
+	client := newKubeClient(t)
+	namespace := setupNamespace(ctx, t, client)
+	deployNginx(ctx, t, client, namespace)
+
+	timeout := int32(600)
+	_, err := client.CoreV1().Services(namespace).Create(ctx, &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "e2e-lb-affinity",
+			Annotations: serviceAnnotations(),
+		},
+		Spec: v1.ServiceSpec{
+			Type:            v1.ServiceTypeLoadBalancer,
+			Selector:        map[string]string{"app": appLabel},
+			SessionAffinity: v1.ServiceAffinityClientIP,
+			SessionAffinityConfig: &v1.SessionAffinityConfig{
+				ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &timeout},
+			},
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   v1.ProtocolTCP,
+				Port:       80,
+				TargetPort: intstr.FromInt32(80),
+			}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	waitForIngress(ctx, t, client, namespace, "e2e-lb-affinity")
+	deleteServiceAndWait(ctx, t, client, namespace, "e2e-lb-affinity")
+}

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -1,0 +1,42 @@
+# Cloud smoke test
+
+Exercises the load balancer implementation against the **real OTC API**
+without needing a Kubernetes cluster: create → verify → idempotent re-ensure
+→ member update → delete. Cheap and fast (one dedicated load balancer for a
+few minutes); everything it creates is removed at the end, also on failure.
+
+Excluded from normal builds by the `smoke` build tag.
+
+## Credentials
+
+Taken from a standard `clouds.yaml` (searched in `./`,
+`~/.config/openstack/`, `/etc/openstack/`, or the path in
+`OS_CLIENT_CONFIG_FILE`), merged with `OS_*` environment variables. Select
+the entry with `OS_CLOUD` when the file has several clouds.
+
+Both auth methods work – username/password or AK/SK (`ak`/`sk` keys in the
+`auth` section of clouds.yaml).
+
+## Required settings
+
+| Variable | Meaning |
+|---|---|
+| `SMOKE_SUBNET_ID` | Neutron subnet ID for the load balancer VIP. |
+| `SMOKE_AVAILABILITY_ZONES` | Comma-separated AZ list, e.g. `eu-de-01`. |
+| `SMOKE_NODE_IP` | An IP inside the subnet to register as a backend member (any free IP works; a real ECS IP makes the health check pass too). |
+| `SMOKE_VPC_ID` | Optional VPC ID. |
+| `SMOKE_EIP_BANDWIDTH` | Optional: also create/release a public EIP (Mbit/s). |
+| `OS_CLOUD` | Optional clouds.yaml entry name. |
+
+## Running
+
+```sh
+export OS_CLOUD=otc
+export SMOKE_SUBNET_ID=<subnet id>
+export SMOKE_AVAILABILITY_ZONES=eu-de-01
+export SMOKE_NODE_IP=192.168.0.10
+make test-smoke
+```
+
+Without credentials or settings the test skips instead of failing, so it is
+safe to include in any environment.

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -1,0 +1,151 @@
+//go:build smoke
+
+// Package smoke exercises the LB implementation against the real OTC API
+// without a Kubernetes cluster; see README.
+package smoke
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/config"
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/elb"
+	"github.com/opentelekomcloud/cloud-provider-opentelekomcloud/pkg/identity"
+)
+
+const clusterName = "smoke"
+
+// smokeEnv holds the resolved test configuration.
+type smokeEnv struct {
+	lb     *elb.LoadBalancer
+	nodeIP string
+}
+
+// setup resolves credentials and SMOKE_* settings, skipping when missing.
+func setup(t *testing.T) *smokeEnv {
+	t.Helper()
+
+	authOpts, err := config.AuthOptsFromCloudsYAML(os.Getenv("OS_CLOUD"))
+	if err != nil {
+		t.Skipf("no usable cloud credentials (clouds.yaml or OS_* env): %v", err)
+	}
+
+	subnetID := os.Getenv("SMOKE_SUBNET_ID")
+	azs := os.Getenv("SMOKE_AVAILABILITY_ZONES")
+	nodeIP := os.Getenv("SMOKE_NODE_IP")
+	if subnetID == "" || azs == "" || nodeIP == "" {
+		t.Skip("SMOKE_SUBNET_ID, SMOKE_AVAILABILITY_ZONES and SMOKE_NODE_IP are required " +
+			"(subnet for the LB VIP, comma-separated AZs, and an IP inside the subnet to register as backend)")
+	}
+
+	idProvider, err := identity.NewIdentityProvider(*authOpts)
+	if err != nil {
+		t.Fatalf("failed to create identity provider: %v", err)
+	}
+
+	lbOpts := config.DefaultLoadBalancerOpts()
+	lbOpts.SubnetID = subnetID
+	lbOpts.VpcID = os.Getenv("SMOKE_VPC_ID")
+	for _, az := range strings.Split(azs, ",") {
+		if az = strings.TrimSpace(az); az != "" {
+			lbOpts.AvailabilityZones = append(lbOpts.AvailabilityZones, az)
+		}
+	}
+
+	return &smokeEnv{
+		lb:     elb.NewLoadBalancer(func() identity.IdentityProvider { return idProvider }, lbOpts),
+		nodeIP: nodeIP,
+	}
+}
+
+func smokeService(name string) *v1.Service {
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "smoke-test",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+			Ports: []v1.ServicePort{{
+				Name:     "http",
+				Protocol: v1.ProtocolTCP,
+				Port:     80,
+				NodePort: 30080,
+			}},
+		},
+	}
+	if bw := os.Getenv("SMOKE_EIP_BANDWIDTH"); bw != "" {
+		svc.Annotations = map[string]string{elb.AnnotationEipBandwidth: bw}
+	}
+	return svc
+}
+
+func smokeNode(ip string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "smoke-node"},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: ip}},
+		},
+	}
+}
+
+// TestCloudSmoke: create, verify, idempotent re-ensure, update, delete.
+func TestCloudSmoke(t *testing.T) {
+	env := setup(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	svc := smokeService(fmt.Sprintf("smoke-%d", time.Now().Unix()))
+	nodes := []*v1.Node{smokeNode(env.nodeIP)}
+
+	// Clean up even when assertions fail.
+	t.Cleanup(func() {
+		if err := env.lb.EnsureLoadBalancerDeleted(context.Background(), clusterName, svc); err != nil {
+			t.Errorf("cleanup failed, cloud resources may be left behind (name prefix %q): %v",
+				env.lb.GetLoadBalancerName(context.Background(), clusterName, svc), err)
+		}
+	})
+
+	// Create.
+	status, err := env.lb.EnsureLoadBalancer(ctx, clusterName, svc, nodes)
+	if err != nil {
+		t.Fatalf("EnsureLoadBalancer failed: %v", err)
+	}
+	if len(status.Ingress) == 0 || status.Ingress[0].IP == "" {
+		t.Fatalf("expected an ingress IP, got %+v", status)
+	}
+	t.Logf("load balancer provisioned with ingress IP %s", status.Ingress[0].IP)
+
+	// Exists.
+	if _, exists, err := env.lb.GetLoadBalancer(ctx, clusterName, svc); err != nil || !exists {
+		t.Fatalf("GetLoadBalancer: exists=%v err=%v", exists, err)
+	}
+
+	// Idempotency.
+	if _, err := env.lb.EnsureLoadBalancer(ctx, clusterName, svc, nodes); err != nil {
+		t.Fatalf("repeated EnsureLoadBalancer failed: %v", err)
+	}
+	t.Log("repeated ensure is idempotent")
+
+	// Member update.
+	if err := env.lb.UpdateLoadBalancer(ctx, clusterName, svc, nodes); err != nil {
+		t.Fatalf("UpdateLoadBalancer failed: %v", err)
+	}
+	t.Log("member update succeeded")
+
+	// Delete and verify.
+	if err := env.lb.EnsureLoadBalancerDeleted(ctx, clusterName, svc); err != nil {
+		t.Fatalf("EnsureLoadBalancerDeleted failed: %v", err)
+	}
+	if _, exists, err := env.lb.GetLoadBalancer(ctx, clusterName, svc); err != nil || exists {
+		t.Fatalf("load balancer still exists after deletion: exists=%v err=%v", exists, err)
+	}
+	t.Log("load balancer deleted")
+}


### PR DESCRIPTION
Implements the `service` controller backed by OTC ELBv3.
- LoadBalancer lifecycle: create/update/delete LBs, listeners, pools, members and health monitors; public LBs via EIP, internal LBs, reuse of existing LBs by ID - configurable through Service annotations
- Config: INI cloud-config with env fallbacks + clouds.yaml support (AK/SK and username/password auth)
- Deployment manifests with least-privilege RBAC scoped to the service controller, docs and example Services
- E2E stand (Terraform + k3s) with deploy script, smoke and e2e tests