### PR TITLE
CI: publish container images and label-gated e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,13 +42,53 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - run: make test
 
+  package_pr:
+    name: package (PR image)
+    # GITHUB_TOKEN has no packages:write on fork PRs.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: [lint, vet, unit_tests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Build the actual head commit, not the synthetic merge commit,
+          # so the image tag matches its content.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push PR image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}
+            ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          build-args: |
+            VERSION=v0.0.0-pr${{ github.event.pull_request.number }}
+            COMMIT=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   eco_check:
     name: eco/check
     if: always()
-    needs: [lint, vet, unit_tests]
+    needs: [lint, vet, unit_tests, package_pr]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
+          allowed-skips: package_pr
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.25'
 

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -61,6 +61,15 @@ jobs:
           prefix              = "ccm-e2e-${{ github.run_id }}"
           ssh_public_key_file = "~/.ssh/id_ed25519.pub"
           EOF
+          # The stand creates a disposable VPC/subnet unless an existing
+          # network is supplied (needed when the CI account may not create
+          # routers, as create_router is disallowed by tenant policy).
+          if [ -n "${{ vars.E2E_NETWORK_ID }}" ]; then
+            cat >> terraform.tfvars <<EOF
+          network_id = "${{ vars.E2E_NETWORK_ID }}"
+          subnet_id  = "${{ vars.E2E_SUBNET_ID }}"
+          EOF
+          fi
 
       - name: Provision test stand
         id: apply
@@ -78,6 +87,14 @@ jobs:
         env:
           E2E_EIP_BANDWIDTH: '10'
         run: KUBECONFIG="$PWD/kubeconfig" make -C ../.. test-e2e
+
+      - name: Show CCM logs and cluster state
+        if: failure()
+        run: |
+          IP=$(terraform output -raw public_ip)
+          ssh -o StrictHostKeyChecking=accept-new "ubuntu@${IP}" \
+            'sudo journalctl -u otc-ccm --no-pager -n 300' || true
+          KUBECONFIG="$PWD/kubeconfig" kubectl get svc,events -A || true
 
       - name: Destroy test stand
         if: always() && steps.apply.outcome != 'skipped'

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened]
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.25'
 

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -35,6 +35,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+      # The wrapper breaks $(terraform output -raw ...) in the helper scripts.
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
 
       - name: Prepare cloud credentials
         env:

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -1,0 +1,79 @@
+name: functional
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+env:
+  GO_VERSION: '1.25'
+
+# One stand per PR at a time; no cancel-in-progress — a cancelled run
+# would skip terraform destroy and leak the ECS/EIP.
+concurrency:
+  group: functional-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  e2e:
+    name: e2e tests
+    # Needs OTC credentials and provisions real cloud resources: run only
+    # for internal PRs labeled 'functional', or on manual dispatch.
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'functional'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      OS_CLOUD: ${{ secrets.OS_CLOUD }}
+      TF_IN_AUTOMATION: 'true'
+    defaults:
+      run:
+        working-directory: hack/e2e-infra
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Prepare cloud credentials
+        env:
+          OS_CLOUDS_YAML_CONTENT: ${{ secrets.OS_CLOUDS_CCM_YAML }}
+        run: |
+          mkdir -p ~/.config/openstack
+          printf '%s' "$OS_CLOUDS_YAML_CONTENT" > ~/.config/openstack/clouds.yaml
+          chmod 600 ~/.config/openstack/clouds.yaml
+          # deploy-ccm.sh reads credentials from clouds.yaml via PyYAML
+          python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --user pyyaml
+
+      - name: Generate ephemeral SSH key
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519
+
+      - name: Write terraform.tfvars
+        run: |
+          cat > terraform.tfvars <<EOF
+          prefix              = "ccm-e2e-${{ github.run_id }}"
+          ssh_public_key_file = "~/.ssh/id_ed25519.pub"
+          EOF
+
+      - name: Provision test stand
+        id: apply
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve -input=false
+
+      - name: Fetch kubeconfig
+        run: ./fetch-kubeconfig.sh
+
+      - name: Deploy cloud controller manager
+        run: MODE=binary ./deploy-ccm.sh
+
+      - name: Run e2e tests
+        env:
+          E2E_EIP_BANDWIDTH: '10'
+        run: KUBECONFIG="$PWD/kubeconfig" make -C ../.. test-e2e
+
+      - name: Destroy test stand
+        if: always() && steps.apply.outcome != 'skipped'
+        run: |
+          terraform init -input=false
+          terraform destroy -auto-approve -input=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  docker:
+    name: build & push release image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/opentelekomcloud/cloud-provider-opentelekomcloud
 go 1.25.5
 
 require (
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.5
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.8
 	gopkg.in/gcfg.v1 v1.2.3
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.5 h1:wJMqv0xU6CcTVZAWVw2qig1j/hn7+5eulpF0A7LGWo0=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8 h1:xBhB2Og/uvciAmeUDDLy9mwMM42lD4CYWAQCBbrEHgE=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/hack/e2e-infra/README.md
+++ b/hack/e2e-infra/README.md
@@ -16,7 +16,7 @@ cd hack/e2e-infra
 export OS_CLOUD=<clouds.yaml entry>          # credentials for terraform/tofu
 export SSH_ARGS="-i ~/.ssh/<key>"            # if not your default key
 
-cp terraform.tfvars.example terraform.tfvars # adjust subnet/network IDs
+cp terraform.tfvars.example terraform.tfvars # optional: reuse an existing subnet/network
 terraform init                               # OpenTofu works too
 terraform apply
 

--- a/hack/e2e-infra/deploy-ccm.sh
+++ b/hack/e2e-infra/deploy-ccm.sh
@@ -17,8 +17,6 @@ SUBNET_ID=$("${TF}" output -raw subnet_id)
 VPC_ID=$("${TF}" output -raw vpc_id)
 AZ=$("${TF}" output -raw availability_zone)
 
-AUTH_URL=${AUTH_URL:-https://iam.eu-de.otc.t-systems.com/v3}
-REGION=${REGION:-eu-de}
 IMAGE=cloud-provider-opentelekomcloud:e2e
 KUBECONFIG_FILE=${KUBECONFIG_FILE:-./kubeconfig}
 KUBECTL="kubectl --kubeconfig=${KUBECONFIG_FILE}"
@@ -56,9 +54,18 @@ if auth.get("project_id"):
     export("OS_PROJECT_ID", auth["project_id"])
 if auth.get("domain_name") or auth.get("user_domain_name"):
     export("OS_DOMAIN_NAME", auth.get("domain_name") or auth["user_domain_name"])
+if auth.get("auth_url"):
+    export("OS_AUTH_URL", auth["auth_url"])
+if cloud.get("region_name"):
+    export("OS_REGION_NAME", cloud["region_name"])
 EOF
 )"
 fi
+
+# Endpoint defaults follow the clouds.yaml entry so the cloud-config talks to
+# the same cloud the credentials belong to.
+AUTH_URL=${AUTH_URL:-${OS_AUTH_URL:-https://iam.eu-de.otc.t-systems.com/v3}}
+REGION=${REGION:-${OS_REGION_NAME:-eu-de}}
 
 # --- cloud-config ---
 CLOUD_CONFIG=$(mktemp)

--- a/hack/e2e-infra/deploy-ccm.sh
+++ b/hack/e2e-infra/deploy-ccm.sh
@@ -24,9 +24,9 @@ KUBECTL="kubectl --kubeconfig=${KUBECONFIG_FILE}"
 [ -f "${KUBECONFIG_FILE}" ] || ./fetch-kubeconfig.sh
 
 # --- credentials ---
-# Prefer username/password with project scope from clouds.yaml; fall back to
-# AK/SK from the environment. The generated cloud-config uses whichever is
-# available (the provider itself prefers AK/SK when both are set).
+# Export every credential the clouds.yaml entry provides; the generated
+# cloud-config carries them all and the provider picks by its own priority
+# (AK/SK > username/password).
 if [ -z "${OS_USERNAME:-}" ] && [ -z "${OS_ACCESS_KEY:-}" ]; then
   echo "no credentials in env, reading clouds.yaml (OS_CLOUD=${OS_CLOUD:-})"
   # Every value is shlex.quote()d: an unquoted secret with spaces or shell
@@ -38,22 +38,27 @@ cloud = yaml.safe_load(open(path))["clouds"][os.environ["OS_CLOUD"]]
 auth = cloud.get("auth", {})
 def export(name, value):
     print(f"export {name}={shlex.quote(str(value))}")
+have_creds = False
 if auth.get("username") and auth.get("password"):
     export("OS_USERNAME", auth["username"])
     export("OS_PASSWORD", auth["password"])
-else:
-    ak = cloud.get("ak") or auth.get("ak")
-    sk = cloud.get("sk") or auth.get("sk")
-    if not ak or not sk:
-        raise SystemExit("no usable credentials in clouds.yaml entry")
+    have_creds = True
+ak = cloud.get("ak") or auth.get("ak")
+sk = cloud.get("sk") or auth.get("sk")
+if ak and sk:
     export("OS_ACCESS_KEY", ak)
     export("OS_SECRET_KEY", sk)
+    have_creds = True
+if not have_creds:
+    raise SystemExit("no usable credentials in clouds.yaml entry")
 if auth.get("project_name"):
     export("OS_PROJECT_NAME", auth["project_name"])
 if auth.get("project_id"):
     export("OS_PROJECT_ID", auth["project_id"])
 if auth.get("domain_name") or auth.get("user_domain_name"):
     export("OS_DOMAIN_NAME", auth.get("domain_name") or auth["user_domain_name"])
+if auth.get("domain_id") or auth.get("user_domain_id"):
+    export("OS_DOMAIN_ID", auth.get("domain_id") or auth["user_domain_id"])
 if auth.get("auth_url"):
     export("OS_AUTH_URL", auth["auth_url"])
 if cloud.get("region_name"):
@@ -81,6 +86,7 @@ secret-key=${OS_SECRET_KEY:-}
 tenant-name=${OS_PROJECT_NAME:-}
 project-id=${OS_PROJECT_ID:-}
 domain-name=${OS_DOMAIN_NAME:-}
+domain-id=${OS_DOMAIN_ID:-}
 
 [LoadBalancer]
 subnet-id=${SUBNET_ID}

--- a/hack/e2e-infra/deploy-ccm.sh
+++ b/hack/e2e-infra/deploy-ccm.sh
@@ -73,26 +73,30 @@ AUTH_URL=${AUTH_URL:-${OS_AUTH_URL:-https://iam.eu-de.otc.t-systems.com/v3}}
 REGION=${REGION:-${OS_REGION_NAME:-eu-de}}
 
 # --- cloud-config ---
+# gcfg silently truncates unquoted values at '#'/';' and errors on '"'/'\',
+# so every credential value is double-quoted with those escaped.
+q() { local v=${1//\\/\\\\}; printf '"%s"' "${v//\"/\\\"}"; }
+
 CLOUD_CONFIG=$(mktemp)
 trap 'rm -f "${CLOUD_CONFIG}"' EXIT
-cat > "${CLOUD_CONFIG}" <<EOF
-[Global]
-auth-url=${AUTH_URL}
-region=${REGION}
-username=${OS_USERNAME:-}
-password=${OS_PASSWORD:-}
-access-key=${OS_ACCESS_KEY:-}
-secret-key=${OS_SECRET_KEY:-}
-tenant-name=${OS_PROJECT_NAME:-}
-project-id=${OS_PROJECT_ID:-}
-domain-name=${OS_DOMAIN_NAME:-}
-domain-id=${OS_DOMAIN_ID:-}
-
-[LoadBalancer]
-subnet-id=${SUBNET_ID}
-vpc-id=${VPC_ID}
-availability-zone=${AZ}
-EOF
+{
+  echo "[Global]"
+  echo "auth-url=$(q "${AUTH_URL}")"
+  echo "region=$(q "${REGION}")"
+  echo "username=$(q "${OS_USERNAME:-}")"
+  echo "password=$(q "${OS_PASSWORD:-}")"
+  echo "access-key=$(q "${OS_ACCESS_KEY:-}")"
+  echo "secret-key=$(q "${OS_SECRET_KEY:-}")"
+  echo "tenant-name=$(q "${OS_PROJECT_NAME:-}")"
+  echo "project-id=$(q "${OS_PROJECT_ID:-}")"
+  echo "domain-name=$(q "${OS_DOMAIN_NAME:-}")"
+  echo "domain-id=$(q "${OS_DOMAIN_ID:-}")"
+  echo
+  echo "[LoadBalancer]"
+  echo "subnet-id=${SUBNET_ID}"
+  echo "vpc-id=${VPC_ID}"
+  echo "availability-zone=${AZ}"
+} > "${CLOUD_CONFIG}"
 
 # MODE=image builds a container image (needs docker) and deploys the
 # manifests; MODE=binary cross-compiles the binary and runs it on the node

--- a/hack/e2e-infra/main.tf
+++ b/hack/e2e-infra/main.tf
@@ -11,6 +11,33 @@ terraform {
 # Credentials come from clouds.yaml; select the entry with OS_CLOUD.
 provider "opentelekomcloud" {}
 
+# Disposable VPC + subnet, created only when no existing network_id is
+# supplied. CIDRs sit inside the default var.vpc_cidr (10.0.0.0/8) so the
+# security group rules below cover them.
+resource "opentelekomcloud_vpc_v1" "vpc" {
+  count = var.network_id == "" ? 1 : 0
+  name  = "${var.prefix}-vpc"
+  cidr  = "10.36.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "subnet" {
+  count         = var.network_id == "" ? 1 : 0
+  name          = "${var.prefix}-subnet"
+  vpc_id        = opentelekomcloud_vpc_v1.vpc[0].id
+  cidr          = "10.36.0.0/24"
+  gateway_ip    = "10.36.0.1"
+  primary_dns   = "100.125.4.25"
+  secondary_dns = "100.125.129.199"
+}
+
+locals {
+  # OTC quirk: a VPC subnet's ID is the neutron *network* UUID, while the
+  # neutron subnet UUID is exposed as its subnet_id attribute.
+  network_id = var.network_id != "" ? var.network_id : opentelekomcloud_vpc_subnet_v1.subnet[0].id
+  subnet_id  = var.subnet_id != "" ? var.subnet_id : opentelekomcloud_vpc_subnet_v1.subnet[0].subnet_id
+  vpc_id     = var.vpc_id != "" ? var.vpc_id : (var.network_id == "" ? opentelekomcloud_vpc_v1.vpc[0].id : "")
+}
+
 resource "opentelekomcloud_networking_floatingip_v2" "node" {
   pool = "admin_external_net"
 }
@@ -80,11 +107,15 @@ resource "opentelekomcloud_compute_instance_v2" "node" {
   })
 
   network {
-    uuid = var.network_id
+    uuid = local.network_id
   }
 }
 
-resource "opentelekomcloud_compute_floatingip_associate_v2" "node" {
+data "opentelekomcloud_networking_port_v2" "node" {
+  device_id = opentelekomcloud_compute_instance_v2.node.id
+}
+
+resource "opentelekomcloud_networking_floatingip_associate_v2" "node" {
   floating_ip = opentelekomcloud_networking_floatingip_v2.node.address
-  instance_id = opentelekomcloud_compute_instance_v2.node.id
+  port_id     = data.opentelekomcloud_networking_port_v2.node.id
 }

--- a/hack/e2e-infra/outputs.tf
+++ b/hack/e2e-infra/outputs.tf
@@ -10,11 +10,11 @@ output "private_ip" {
 
 output "subnet_id" {
   description = "Neutron subnet ID for the cloud provider [LoadBalancer] section"
-  value       = var.subnet_id
+  value       = local.subnet_id
 }
 
 output "vpc_id" {
-  value = var.vpc_id
+  value = local.vpc_id
 }
 
 output "availability_zone" {

--- a/hack/e2e-infra/terraform.tfvars.example
+++ b/hack/e2e-infra/terraform.tfvars.example
@@ -1,8 +1,10 @@
-# openstack subnet list --long   ->   ID = subnet_id, Network = network_id
-network_id = "a2d7c9f1-7fd9-4943-af53-352538943ab3"
-subnet_id  = "c6e0eba4-17aa-4e16-9522-76a12969deb7"
+# Leave network_id/subnet_id unset to create a disposable VPC + subnet.
+# To reuse an existing network instead:
+#   openstack subnet list --long   ->   ID = subnet_id, Network = network_id
+#network_id = "a2d7c9f1-7fd9-4943-af53-352538943ab3"
+#subnet_id  = "c6e0eba4-17aa-4e16-9522-76a12969deb7"
 # openstack router list (VPC id), optional
-vpc_id = ""
+#vpc_id = ""
 
 availability_zone = "eu-de-01"
 # Restrict SSH/API access to your IP if desired:

--- a/hack/e2e-infra/variables.tf
+++ b/hack/e2e-infra/variables.tf
@@ -5,13 +5,15 @@ variable "prefix" {
 }
 
 variable "network_id" {
-  description = "OTC network UUID of the subnet the node attaches to (openstack subnet list, column Network)"
+  description = "OTC network UUID of an existing subnet the node attaches to (openstack subnet list, column Network); leave empty to create a disposable VPC + subnet"
   type        = string
+  default     = ""
 }
 
 variable "subnet_id" {
-  description = "Neutron subnet UUID used by the cloud provider for load balancer VIPs (openstack subnet list, column ID)"
+  description = "Neutron subnet UUID used by the cloud provider for load balancer VIPs (openstack subnet list, column ID); leave empty together with network_id to create one"
   type        = string
+  default     = ""
 }
 
 variable "vpc_id" {

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,7 +6,11 @@ deployment and `LoadBalancer` Services, wait for the load balancer to be
 provisioned, optionally verify HTTP reachability, and clean everything up.
 
 They are excluded from normal builds by the `e2e` build tag and never run as
-part of `make test` or CI unit tests.
+part of `make test` or CI unit tests. In CI the `functional` workflow runs
+them for internal pull requests labeled `functional` (or via manual
+dispatch): it provisions the disposable stand from
+[`hack/e2e-infra`](../../hack/e2e-infra), runs the tests and destroys the
+stand afterwards.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Image publishing (#19)

Closes #19
Closes #20

- `ci.yaml`: new `package_pr` job — after checks pass, pushes the image to ghcr.io tagged `pr-<number>` and `pr-<number>-<sha>` (internal PRs only)
- `release.yaml`: on `v*` tag push — pushes the image tagged with the release tag and `latest`
- `functional.yaml`: runs the e2e tests from `test/e2e` on PRs labeled `functional` (or manually): provisions the stand from `hack/e2e-infra`, deploys the CCM, runs the tests, always destroys the stand
- `hack/e2e-infra`: the stand now creates its own VPC/subnet, so CI needs no pre-provisioned network; deprecated floating IP resource replaced
- gophertelekomcloud bumped to v0.9.8